### PR TITLE
feat(cove): add verifier_context kwarg for per-step CoVe context (#4)

### DIFF
--- a/promptchain/utils/agentic_step_processor.py
+++ b/promptchain/utils/agentic_step_processor.py
@@ -229,6 +229,7 @@ class AgenticStepProcessor:
         enable_cove: bool = False,  # Enable Chain of Verification (pre-execution validation)
         enable_checkpointing: bool = False,  # Enable epistemic checkpointing (stuck state detection)
         cove_confidence_threshold: float = 0.7,  # Minimum confidence to execute tool (0.0 to 1.0)
+        verifier_context: Optional[str] = None,  # Step-specific context appended to CoVe verification prompt (Issue #4)
         # TAO Loop + Dry Runs parameters (Phase 4: Transparent Reasoning - explicit Think-Act-Observe)
         enable_tao_loop: bool = False,  # Enable explicit Think-Act-Observe loop (default: off, uses implicit ReAct)
         enable_dry_run: bool = False,  # Enable tool outcome prediction before execution (transparent reasoning)
@@ -292,6 +293,17 @@ class AgenticStepProcessor:
                                      Tools with verification confidence below this threshold are skipped.
                                      Range: 0.0 (execute everything) to 1.0 (only execute very confident calls).
                                      Recommended: 0.7 for balance, 0.9 for critical operations.
+            verifier_context: (Optional) Step-specific context appended to the CoVe verification prompt
+                            under a "## Step Context" heading. Use this on chains with v0.6.1 per-step
+                            tool scoping `(step, ["tool_a", "tool_b"])` where the verifier — which only
+                            sees tool name + schema + args — would otherwise over-reject legitimate,
+                            hand-vetted calls (issue #4). Example:
+                                verifier_context=(
+                                    "You are part of REMEDIATE_PRE in a self-healing pipeline. "
+                                    "All available fixes are idempotent, worktree-local operations "
+                                    "pre-vetted by the chain author. Approve unless args are obviously wrong."
+                                )
+                            Empty default preserves existing behaviour. Has no effect when enable_cove=False.
             instructions: (Deprecated) List of extra instruction strings. When supplied alone, a DeprecationWarning is emitted
                           and the instructions are forwarded to the default DynamicPromptGenerator via extra_instructions.
                           Passing both `instructions` and `prompt_builder` raises ValueError (mutually exclusive).
@@ -376,6 +388,7 @@ class AgenticStepProcessor:
         # Chain of Verification (Phase 3: Safety & Reliability - 40-50% error reduction)
         self.enable_cove = enable_cove
         self.cove_confidence_threshold = cove_confidence_threshold
+        self.verifier_context = verifier_context
         self.cove_verifier: Optional[Any] = None  # Lazy init - created on first use
         if self.enable_cove:
             logger.info(
@@ -904,7 +917,11 @@ class AgenticStepProcessor:
             verification_model = (
                 self.fallback_model if self.fallback_model else self.model_name
             ) or ""
-            self.cove_verifier = CoVeVerifier(llm_runner, verification_model)
+            self.cove_verifier = CoVeVerifier(
+                llm_runner,
+                verification_model,
+                extra_context=self.verifier_context,
+            )
             logger.info(f"[CoVe] Initialized verifier with model: {verification_model}")
 
     async def run_async(

--- a/promptchain/utils/verification.py
+++ b/promptchain/utils/verification.py
@@ -82,16 +82,29 @@ class CoVeVerifier:
     before they execute.
     """
 
-    def __init__(self, llm_runner: Callable, model_name: str):
+    def __init__(
+        self,
+        llm_runner: Callable,
+        model_name: str,
+        extra_context: Optional[str] = None,
+    ):
         """
         Initialize CoVe verifier.
 
         Args:
             llm_runner: Async function that calls LLM (same signature as AgenticStepProcessor.llm_runner)
             model_name: Model to use for verification (can be cheaper/faster than primary model)
+            extra_context: Optional step-specific context appended to the verification prompt
+                under a "## Step Context" heading. Lets chain authors hint to the verifier
+                why the curated tool list at this step is safe (e.g., "all fixes are
+                idempotent and pre-vetted"). Without this, on chains using v0.6.1 per-step
+                tool scoping the verifier — which only sees tool name + schema + args —
+                conservatively over-rejects legitimate calls. Empty default preserves
+                backward-compatible behavior.
         """
         self.llm_runner = llm_runner
         self.model_name = model_name
+        self.extra_context = extra_context
         logger.info(f"[CoVe] Initialized with model: {model_name}")
 
     async def verify_tool_call(
@@ -215,6 +228,9 @@ Think through each question carefully, then respond in valid JSON format:
 }}
 
 IMPORTANT: Respond ONLY with valid JSON, no additional text."""
+
+        if self.extra_context:
+            prompt += f"\n\n## Step Context\n{self.extra_context}\n"
 
         return prompt
 

--- a/tests/test_cove_verifier_context.py
+++ b/tests/test_cove_verifier_context.py
@@ -1,0 +1,112 @@
+"""Tests for `verifier_context` — per-step CoVe verification prompt context (Issue #4).
+
+Background: after the v0.6.1 lambda-signature fix, CoVe ran cleanly but began
+over-rejecting legitimate, hand-vetted tool calls in chains using per-step tool
+scoping `(step, ["tool_a", "tool_b"])`. Root cause: the verifier sees only the
+tool name + JSON schema + args — it never sees the AgenticStepProcessor's
+objective. With no domain context it conservatively defaults to
+``should_execute=False`` even at confidence=1.00.
+
+Fix (Option A from PRD `promptchain_cove_verifier_context_2026-05-08`): a new
+``verifier_context: str`` kwarg on ``AgenticStepProcessor`` is plumbed down to
+``CoVeVerifier`` as ``extra_context``, where ``_build_verification_prompt``
+appends it under a "## Step Context" heading.
+
+These tests cover three behaviours:
+    (a) empty verifier_context → identical prompt to current behaviour
+    (b) populated verifier_context → flows into the verification prompt
+    (c) AgenticStepProcessor wires the kwarg through to CoVeVerifier on lazy init
+"""
+from __future__ import annotations
+
+from promptchain.utils.agentic_step_processor import AgenticStepProcessor
+from promptchain.utils.verification import CoVeVerifier
+
+
+def _make_verifier(extra_context=None):
+    """CoVeVerifier with a no-op llm_runner — we only inspect prompt-building, not LLM calls."""
+    async def noop_runner(messages, model=None, **kwargs):
+        return {"content": ""}
+    return CoVeVerifier(
+        llm_runner=noop_runner,
+        model_name="openai/gpt-4o-mini",
+        extra_context=extra_context,
+    )
+
+
+def test_empty_verifier_context_preserves_current_behaviour():
+    """No extra_context → no '## Step Context' section in the verification prompt.
+
+    Backward-compat guard: existing CoVe users (no v0.6.1 per-step scoping)
+    must see an unchanged prompt.
+    """
+    verifier = _make_verifier(extra_context=None)
+    prompt = verifier._build_verification_prompt(
+        tool_name="my_tool",
+        tool_args={"a": 1},
+        tool_schema={"name": "my_tool"},
+        context="some current context",
+    )
+    assert "## Step Context" not in prompt
+    assert "my_tool" in prompt  # sanity — base prompt still built
+
+
+def test_populated_verifier_context_flows_into_prompt():
+    """Populated extra_context → appended under '## Step Context' heading."""
+    ctx = (
+        "You are part of REMEDIATE_PRE in a self-healing pipeline. "
+        "All available fixes are pre-vetted and idempotent."
+    )
+    verifier = _make_verifier(extra_context=ctx)
+    prompt = verifier._build_verification_prompt(
+        tool_name="fix_set_hh_worktree_mode",
+        tool_args={},
+        tool_schema={"name": "fix_set_hh_worktree_mode"},
+        context="some current context",
+    )
+    assert "## Step Context" in prompt
+    assert ctx in prompt
+    # Heading must come AFTER the JSON-only instruction so the verifier still
+    # treats it as supplementary context (not a replacement for the checklist).
+    assert prompt.index("VERIFICATION CHECKLIST") < prompt.index("## Step Context")
+
+
+def test_agentic_step_processor_plumbs_verifier_context_to_cove_verifier():
+    """The kwarg on AgenticStepProcessor must reach CoVeVerifier.extra_context.
+
+    Exercises the lazy-init wiring in ``_ensure_cove_verifier`` end-to-end without
+    spinning up a chain.
+    """
+    ctx = "Step-specific safety hint."
+    asp = AgenticStepProcessor(
+        objective="Demo objective.",
+        model_name="openai/gpt-4o-mini",
+        enable_cove=True,
+        verifier_context=ctx,
+    )
+    assert asp.verifier_context == ctx
+    assert asp.cove_verifier is None  # lazy
+
+    async def noop_runner(messages, model=None, **kwargs):
+        return {"content": ""}
+
+    asp._ensure_cove_verifier(noop_runner)
+    assert asp.cove_verifier is not None
+    assert asp.cove_verifier.extra_context == ctx
+
+
+def test_verifier_context_default_is_none_backward_compat():
+    """Existing AgenticStepProcessor(enable_cove=True) callers must keep working
+    without the new kwarg — extra_context defaults to None on the verifier."""
+    asp = AgenticStepProcessor(
+        objective="Demo.",
+        model_name="openai/gpt-4o-mini",
+        enable_cove=True,
+    )
+    assert asp.verifier_context is None
+
+    async def noop_runner(messages, model=None, **kwargs):
+        return {"content": ""}
+
+    asp._ensure_cove_verifier(noop_runner)
+    assert asp.cove_verifier.extra_context is None


### PR DESCRIPTION
## Summary

Closes #4. Implements **Option A** from the issue: a new `verifier_context: str` kwarg on `AgenticStepProcessor` is plumbed down to `CoVeVerifier` as `extra_context`, where `_build_verification_prompt` appends it under a `## Step Context` heading.

## Why

After the v0.6.1 lambda-signature fix (`d2f6286` + `05aae1f`), CoVe stopped TypeErroring — but began **rejecting legitimate, hand-vetted tool calls** in chains using per-step tool scoping `(step, ["tool_a", "tool_b"])`. The verifier sees only the tool name, JSON schema, and args — never the `AgenticStepProcessor`'s objective. With no domain context, it conservatively defaults to `should_execute=False` even at `confidence=1.00`.

The new kwarg lets chain authors pass a one-paragraph "here's why these tools are safe at this step" hint to the verifier. Empty default = identical prompt to current behaviour. Has no effect when `enable_cove=False`.

## What changed

| File | Change |
|---|---|
| `promptchain/utils/verification.py` | `CoVeVerifier.__init__` accepts `extra_context: Optional[str]`; `_build_verification_prompt` appends it under `## Step Context` |
| `promptchain/utils/agentic_step_processor.py` | New `verifier_context` kwarg; plumbed through `_ensure_cove_verifier` |
| `tests/test_cove_verifier_context.py` | 4 tests (empty / populated / plumbing / backward-compat default) |

~20 LOC of behaviour change + 112 LOC of tests.

## Test plan

- [x] `tests/test_cove_verifier_context.py` — 4 new tests passing (empty preserves prompt, populated flows in, ASP plumbs it through to CoVeVerifier, default-None keeps existing callers working)
- [x] `tests/test_cove_per_step_scope_regression.py` — 2 sibling tests still passing
- [x] `tests/test_verification.py` + `tests/test_verification_integration.py` — 20 pre-existing failures **unchanged** (verified by stashing changes; identical failure set against `main`). Net: zero regressions, +6 passes.
- [ ] Downstream consumer (hh-stack) flips `enable_cove=True` back on with populated `verifier_context` per AgenticStepProcessor and runs cleanly.

## Backward compatibility

100% backward-compatible. `verifier_context` defaults to `None` → empty `extra_context` on the verifier → no `## Step Context` section → byte-identical prompt to today's behaviour for existing `enable_cove=True` callers.

## Side improvement (deferred to separate PR)

Issue #4 §7 also proposes improving the `[CoVe] ❌ Skipped …` log to include `should_execute=` and `reasoning=` (would have shaved hours off the original debug). Keeping out of this PR to keep scope tight; will land separately.

## Origin

Discovered downstream by hh-stack live run #4 on 2026-05-08, immediately after the lambda-signature fix landed. Workaround in place: `enable_cove=False`. Will re-enable post-merge.