### PR TITLE
fix(observability): default MLflow tracking to sqlite (3.x file-store maintenance-mode)

### DIFF
--- a/promptchain/observability/config.py
+++ b/promptchain/observability/config.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 # Default configuration values
 DEFAULT_MLFLOW_ENABLED = False
-DEFAULT_TRACKING_URI = "http://localhost:5000"
+DEFAULT_TRACKING_URI = "sqlite:///mlflow.db"
 DEFAULT_EXPERIMENT_NAME = "promptchain-cli"
 DEFAULT_BACKGROUND_LOGGING = True
 

--- a/promptchain/observability/mlflow_adapter.py
+++ b/promptchain/observability/mlflow_adapter.py
@@ -60,7 +60,7 @@ def initialize_mlflow(
     Initialize MLflow with tracking URI and experiment.
 
     Args:
-        tracking_uri: MLflow tracking server URI (default: ./mlruns)
+        tracking_uri: MLflow tracking URI (default: sqlite:///mlflow.db)
         experiment_name: Name of the experiment (default: PromptChain)
 
     Returns:

--- a/scripts/observe.sh
+++ b/scripts/observe.sh
@@ -53,7 +53,7 @@ if [ -f "$REPO_ROOT/.env" ]; then
 fi
 
 # Default MLflow config (project-local)
-export MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI:-file://$REPO_ROOT/mlruns}"
+export MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI:-sqlite:///$REPO_ROOT/mlflow.db}"
 export PROMPTCHAIN_MLFLOW_BACKGROUND="${PROMPTCHAIN_MLFLOW_BACKGROUND:-1}"
 
 LOG="$RUN_DIR/output.log"


### PR DESCRIPTION
## Problem
MLflow 3.x put the filesystem tracking backend (`file://./mlruns`) into *maintenance mode* — it now raises `MlflowException` instead of logging. So on a fresh `pip install mlflow` (3.14.0), PromptChain's observability + `mlflow ui` break even though `init_mlflow()` looks wired. Reproduced live on 3.14.0.

## Fix (default to sqlite — MLflow 3.x-native)
- `promptchain/observability/config.py`: `DEFAULT_TRACKING_URI` `http://localhost:5000` → `sqlite:///mlflow.db` (works out of the box, no tracking server needed)
- `scripts/observe.sh`: `file://$REPO_ROOT/mlruns` → `sqlite:///$REPO_ROOT/mlflow.db`
- `mlflow_adapter.py`: fix stale `(default: ./mlruns)` docstring

## Verification (mlflow 3.14.0)
`get_tracking_uri()` → `sqlite:///mlflow.db`; `initialize_mlflow()` → True; `MlflowClient().search_experiments()` no longer raises. `mlflow ui --backend-store-uri sqlite:///mlflow.db` works. Existing `mlruns/` data migratable via `mlflow migrate-filestore`.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)