### PR TITLE
feat: litellm-free RawCaller for API-agnostic, experiment-pure model calls

### DIFF
--- a/promptchain/utils/raw_caller.py
+++ b/promptchain/utils/raw_caller.py
@@ -1,0 +1,91 @@
+"""RawCaller — a litellm-free, passthrough HTTP client for PromptChain (issue #31).
+
+Why: litellm is a hidden normalization layer. For tool calls it can inject tool-use instructions
+into the system prompt, force ollama `format=json`, parse raw output into `tool_calls` itself, rewrite
+roles/params, and `drop_params=True` silently deletes params. That contaminates a "naked model"
+experiment and couples PromptChain to litellm's provider conventions.
+
+RawCaller is the opposite: a STRICT PASSTHROUGH. It POSTs exactly the messages + explicit params you
+give it — no system-prompt injection, no role rewriting, no tool-prompt injection, no output parsing,
+no silent defaults — and returns the raw provider JSON (plus thin `.text`/`.usage` accessors). Tool
+calling is the caller's job via `promptchain.utils.tool_normalization` (render + parse), so WE own the
+normalization and its leniency dial.
+
+Stdlib only (urllib) on purpose: the whole point is a caller with no hidden behavior to audit.
+litellm stays PromptChain's default; RawCaller is OPT-IN for experiments, naked models, and
+provider-agnostic deployments (ollama /api/chat, OpenAI-compatible /v1, llama.cpp, MLX, base HTTP).
+"""
+import json
+import urllib.request
+import urllib.error
+
+
+class RawResponse:
+    """Thin wrapper over the raw provider JSON. `.raw` is the untouched dict; accessors normalize
+    only the two fields callers usually need, without hiding anything."""
+
+    def __init__(self, raw: dict, api_style: str):
+        self.raw = raw
+        self.api_style = api_style
+
+    @property
+    def text(self) -> str:
+        if self.api_style == "ollama":
+            return ((self.raw.get("message") or {}).get("content") or "")
+        ch = (self.raw.get("choices") or [{}])[0]
+        return ((ch.get("message") or {}).get("content") or "")
+
+    @property
+    def usage(self) -> dict:
+        if self.api_style == "ollama":
+            return {"prompt_tokens": int(self.raw.get("prompt_eval_count", 0) or 0),
+                    "completion_tokens": int(self.raw.get("eval_count", 0) or 0)}
+        return self.raw.get("usage") or {}
+
+
+class RawCaller:
+    """Passthrough caller. `api_style` selects the wire format:
+      - "openai": POST {base_url}/chat/completions with {model, messages, **params}
+      - "ollama": POST {base_url}/api/chat        with {model, messages, stream:false, options:params}
+    `base_url` should include the /v1 for openai-style endpoints (e.g. http://host:8771/v1)."""
+
+    def __init__(self, base_url: str, model: str | None = None, api_key: str | None = None,
+                 api_style: str = "openai", default_params: dict | None = None,
+                 headers: dict | None = None, timeout: int = 600):
+        if api_style not in ("openai", "ollama"):
+            raise ValueError("api_style must be 'openai' or 'ollama'")
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.api_key = api_key
+        self.api_style = api_style
+        self.default_params = dict(default_params or {})
+        self.headers = dict(headers or {})
+        self.timeout = timeout
+
+    def build_payload(self, messages, model=None, params=None) -> dict:
+        """The EXACT dict that will be POSTed. Exposed so passthrough purity is testable/auditable.
+        No injection: `messages` is passed through verbatim; only explicit params are merged."""
+        model = model or self.model
+        p = {**self.default_params, **(params or {})}
+        if self.api_style == "ollama":
+            payload = {"model": model, "messages": messages, "stream": False}
+            if p:
+                payload["options"] = p
+            return payload
+        payload = {"model": model, "messages": messages}
+        payload.update(p)
+        return payload
+
+    def _endpoint(self) -> str:
+        return self.base_url + ("/api/chat" if self.api_style == "ollama" else "/chat/completions")
+
+    def complete(self, messages, model=None, params=None) -> RawResponse:
+        payload = self.build_payload(messages, model=model, params=params)
+        data = json.dumps(payload).encode("utf-8")
+        hdr = {"Content-Type": "application/json", **self.headers}
+        if self.api_key:
+            hdr["Authorization"] = f"Bearer {self.api_key}"
+        req = urllib.request.Request(self._endpoint(), data=data, headers=hdr, method="POST")
+        with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+            raw = json.loads(resp.read().decode("utf-8"))
+        return RawResponse(raw, self.api_style)

--- a/tests/test_raw_caller.py
+++ b/tests/test_raw_caller.py
@@ -1,0 +1,50 @@
+"""Tests for RawCaller (issue #31) — the point is to PROVE strict passthrough: no injection,
+no hidden keys, no output parsing. All offline (payload builder + response accessors)."""
+from promptchain.utils.raw_caller import RawCaller, RawResponse
+
+
+def test_openai_payload_is_exact_passthrough():
+    rc = RawCaller("http://x/v1", model="m", api_style="openai")
+    msgs = [{"role": "system", "content": "S"}, {"role": "user", "content": "hi"}]
+    p = rc.build_payload(msgs, params={"temperature": 0.0, "seed": 7})
+    # EXACTLY model + messages + the params we gave — nothing injected
+    assert p == {"model": "m", "messages": msgs, "temperature": 0.0, "seed": 7}
+    assert p["messages"] is msgs  # messages passed through verbatim, not rewritten
+
+
+def test_openai_no_hidden_keys_when_no_params():
+    rc = RawCaller("http://x/v1", model="m")
+    p = rc.build_payload([{"role": "user", "content": "hi"}])
+    assert set(p.keys()) == {"model", "messages"}  # no temperature/stop/tools invented
+
+
+def test_ollama_payload_shape_and_passthrough():
+    rc = RawCaller("http://h:11434", model="m", api_style="ollama", default_params={"temperature": 0.2})
+    msgs = [{"role": "user", "content": "hi"}]
+    p = rc.build_payload(msgs, params={"seed": 1})
+    assert p == {"model": "m", "messages": msgs, "stream": False, "options": {"temperature": 0.2, "seed": 1}}
+
+
+def test_endpoint_selection():
+    assert RawCaller("http://x/v1", api_style="openai")._endpoint() == "http://x/v1/chat/completions"
+    assert RawCaller("http://x", api_style="ollama")._endpoint() == "http://x/api/chat"
+
+
+def test_bad_api_style_rejected():
+    try:
+        RawCaller("http://x", api_style="anthropic-magic")
+        assert False, "should have raised"
+    except ValueError:
+        pass
+
+
+def test_response_accessors_openai():
+    r = RawResponse({"choices": [{"message": {"content": "hello"}}],
+                     "usage": {"prompt_tokens": 8, "completion_tokens": 3}}, "openai")
+    assert r.text == "hello" and r.usage["prompt_tokens"] == 8
+
+
+def test_response_accessors_ollama():
+    r = RawResponse({"message": {"content": "hi"}, "prompt_eval_count": 5, "eval_count": 2}, "ollama")
+    assert r.text == "hi"
+    assert r.usage == {"prompt_tokens": 5, "completion_tokens": 2}


### PR DESCRIPTION
Implements #31. Stdlib `RawCaller` (openai + ollama api_style) with a strict passthrough contract — sends exactly the messages + explicit params, no injection/parsing/defaults, raw JSON back (+ .text/.usage). Pairs with the merged `tool_normalization` for caller-owned tool-calling. litellm stays default; RawCaller is opt-in.

7 offline tests prove passthrough (exact payload == input, no hidden keys, endpoint selection, both response styles). Closes #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)