### PR TITLE
feat: LlamaCppCaller — in-process llama.cpp caller with grammar toggle

### DIFF
--- a/promptchain/utils/llama_cpp_caller.py
+++ b/promptchain/utils/llama_cpp_caller.py
@@ -1,0 +1,88 @@
+"""LlamaCppCaller — in-process llama.cpp (llama-cpp-python) caller for PromptChain (issue #33).
+
+WHY (tracked): litellm AND ollama both normalize tool calls — injecting tool-use prompts, forcing
+`format=json`, and parsing raw output into `tool_calls`. So a naked-model experiment routed through
+them can never surface a malformed call, and we can't test whether a strong corrector repairs a
+weak/quantized model's mistakes. Structural validity is already a solved problem (llama.cpp GBNF
+grammars / vLLM guided decoding guarantee valid JSON); the unsolved gap is semantic/judgment
+correctness, which is where quantized models degrade.
+
+LlamaCppCaller runs GGUF weights DIRECTLY (no litellm, no ollama) with a GRAMMAR TOGGLE:
+  • grammar=None       -> RAW, malformable output (repair experiments on crushed models)
+  • grammar=<GBNF str> -> structurally-constrained valid output (the production / solved-syntax path)
+
+Tool-calling is the caller's job via promptchain.utils.tool_normalization (render + parse, leniency
+dial). litellm stays PromptChain's default; this is OPT-IN for experiments and local Metal inference.
+`llama-cpp-python` is a lazy, OPTIONAL dependency — importing this module never requires it.
+"""
+
+_UNSET = object()  # distinguishes "grammar not passed" (use instance default) from "grammar=None" (raw)
+
+
+class LlamaCppResponse:
+    """Wrapper over llama-cpp-python's OpenAI-shaped chat-completion dict. `.raw` is untouched."""
+
+    def __init__(self, raw: dict):
+        self.raw = raw
+
+    @property
+    def text(self) -> str:
+        ch = (self.raw.get("choices") or [{}])[0]
+        return ((ch.get("message") or {}).get("content") or "")
+
+    @property
+    def usage(self) -> dict:
+        return self.raw.get("usage") or {}
+
+
+class LlamaCppCaller:
+    """Load a GGUF model with llama-cpp-python and run chat completions in-process.
+
+    grammar (instance-level default) and the per-call `grammar` arg control decoding:
+      unset (default)    -> use the instance default
+      None               -> RAW output (no grammar; malformation survives)
+      "<GBNF string>"    -> constrained decoding (guaranteed to match the grammar)
+    """
+
+    def __init__(self, model_path, n_ctx=8192, n_gpu_layers=-1, chat_format=None,
+                 default_params=None, grammar=None, verbose=False):
+        self.model_path = model_path
+        self.n_ctx = n_ctx
+        self.n_gpu_layers = n_gpu_layers          # -1 = offload all layers to Metal/GPU
+        self.chat_format = chat_format            # None = use the GGUF's built-in template
+        self.default_params = dict(default_params or {})
+        self.grammar_default = grammar            # GBNF string or None (None = raw)
+        self.verbose = verbose
+        self._llm = None                          # lazy-loaded Llama instance
+
+    def _ensure_loaded(self):
+        if self._llm is None:
+            try:
+                from llama_cpp import Llama
+            except ImportError as e:  # pragma: no cover - env-dependent
+                raise ImportError(
+                    "LlamaCppCaller requires the optional dependency 'llama-cpp-python'. "
+                    "Install: pip install llama-cpp-python  "
+                    "(macOS/Metal: CMAKE_ARGS='-DGGML_METAL=on' pip install llama-cpp-python)"
+                ) from e
+            self._llm = Llama(model_path=self.model_path, n_ctx=self.n_ctx,
+                              n_gpu_layers=self.n_gpu_layers, chat_format=self.chat_format,
+                              verbose=self.verbose)
+        return self._llm
+
+    def resolve(self, params=None, grammar=_UNSET):
+        """Merge params and resolve the grammar to use (per-call arg overrides the instance default).
+        Returns (merged_params, grammar_gbnf_or_None). Pure/offline — the unit-testable core."""
+        merged = {**self.default_params, **(params or {})}
+        gbnf = self.grammar_default if grammar is _UNSET else grammar
+        return merged, gbnf
+
+    def complete(self, messages, params=None, grammar=_UNSET) -> LlamaCppResponse:
+        llm = self._ensure_loaded()
+        merged, gbnf = self.resolve(params, grammar)
+        gram = None
+        if gbnf:
+            from llama_cpp import LlamaGrammar
+            gram = LlamaGrammar.from_string(gbnf)
+        raw = llm.create_chat_completion(messages=messages, grammar=gram, **merged)
+        return LlamaCppResponse(raw)

--- a/tests/test_llama_cpp_caller.py
+++ b/tests/test_llama_cpp_caller.py
@@ -1,0 +1,51 @@
+"""Tests for LlamaCppCaller (issue #33) — grammar-toggle + param resolution + response parsing.
+All offline: no model load, no llama-cpp-python required (lazy import)."""
+from promptchain.utils.llama_cpp_caller import LlamaCppCaller, LlamaCppResponse, _UNSET
+
+
+def test_grammar_unset_uses_instance_default():
+    c = LlamaCppCaller("m.gguf", grammar="root ::= object")
+    _, g = c.resolve(grammar=_UNSET)
+    assert g == "root ::= object"
+
+
+def test_grammar_none_overrides_to_raw():
+    # explicit None must beat the instance default → RAW/malformable output
+    c = LlamaCppCaller("m.gguf", grammar="root ::= object")
+    _, g = c.resolve(grammar=None)
+    assert g is None
+
+
+def test_grammar_string_override():
+    c = LlamaCppCaller("m.gguf", grammar=None)
+    _, g = c.resolve(grammar="root ::= json")
+    assert g == "root ::= json"
+
+
+def test_default_is_raw():
+    # no grammar given at all → raw (None) by default
+    c = LlamaCppCaller("m.gguf")
+    _, g = c.resolve()
+    assert g is None
+
+
+def test_params_merge_call_overrides_instance():
+    c = LlamaCppCaller("m.gguf", default_params={"temperature": 0.2, "top_p": 0.9})
+    merged, _ = c.resolve(params={"temperature": 0.0})
+    assert merged == {"temperature": 0.0, "top_p": 0.9}
+
+
+def test_lazy_no_model_load_on_construct():
+    c = LlamaCppCaller("/nonexistent.gguf")
+    assert c._llm is None  # constructing must not load the model
+
+
+def test_response_accessors():
+    r = LlamaCppResponse({"choices": [{"message": {"content": "hi"}}],
+                          "usage": {"prompt_tokens": 4, "completion_tokens": 1}})
+    assert r.text == "hi" and r.usage["prompt_tokens"] == 4
+
+
+def test_response_empty_safe():
+    r = LlamaCppResponse({})
+    assert r.text == "" and r.usage == {}


### PR DESCRIPTION
Implements #33. Runs GGUF weights directly via llama-cpp-python (lazy/optional dep) with a **grammar toggle**: `grammar=None` → raw malformable output (for repair experiments on crushed models), `grammar=<GBNF>` → structurally-constrained valid output. No litellm, no ollama. Tool-calling via the merged `tool_normalization`. Opt-in; litellm stays default.

8 offline tests (grammar resolution/override, param merge, lazy no-load, response accessors). See #33 for the full reasoning trail. Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)