### PR TITLE
feat: MLXCaller — in-process Apple-Silicon (MLX) caller for original HF weights

### DIFF
--- a/promptchain/utils/mlx_caller.py
+++ b/promptchain/utils/mlx_caller.py
@@ -1,0 +1,69 @@
+"""MLXCaller — in-process Apple-Silicon (MLX) caller for PromptChain (issue #35).
+
+WHY (tracked): experiment models must load on the Mac Studio (Apple Silicon, Metal) — the orchestrating
+Linux box can't afford them. LlamaCppCaller (#33/#34) covers crushed GGUF quants in-process on the Mac;
+MLXCaller is the sibling for ORIGINAL/un-quantized HF weights, where MLX (`mlx-lm`) is the best
+Apple-Silicon runtime (native, unified-memory-efficient, first-class Metal).
+
+Naked by design: no litellm, no ollama — so nothing injects tool prompts, forces `format=json`, or
+parses output. The ONE normalization is the chat template, applied EXPLICITLY here (we control it, or
+skip it). Tool-calling is the caller's job via promptchain.utils.tool_normalization (render + parse).
+`mlx-lm` is a lazy, OPTIONAL dependency (Apple Silicon only); importing this module never requires it.
+"""
+
+
+class MLXResponse:
+    """Wrapper over the generated text (mlx_lm.generate returns text). `.text` is the raw output;
+    `.usage` is populated only if the caller passes token counts in (mlx_lm generate is text-only)."""
+
+    def __init__(self, text: str, usage: dict | None = None):
+        self.text = text or ""
+        self.usage = usage or {}
+
+
+class MLXCaller:
+    """Load HF weights with mlx_lm and generate in-process on Apple Silicon.
+
+    use_chat_template=True → apply the tokenizer's chat template (roles/special tokens the model
+    expects) — the only normalization, and it's explicit/ours. False → raw concatenation of contents.
+    """
+
+    def __init__(self, model_path, default_params=None, use_chat_template=True):
+        self.model_path = model_path
+        self.default_params = dict(default_params or {})
+        self.use_chat_template = use_chat_template
+        self._model = None
+        self._tok = None
+
+    def _ensure_loaded(self):
+        if self._model is None:
+            try:
+                from mlx_lm import load
+            except ImportError as e:  # pragma: no cover - env-dependent (Apple Silicon only)
+                raise ImportError(
+                    "MLXCaller requires the optional dependency 'mlx-lm' (Apple Silicon only). "
+                    "Install on the Mac: pip install mlx-lm"
+                ) from e
+            self._model, self._tok = load(self.model_path)
+        return self._model, self._tok
+
+    def build_prompt(self, messages, tokenizer=None) -> str:
+        """Turn messages into the prompt string. With use_chat_template, apply the tokenizer's chat
+        template (add generation prompt, no tokenize); else raw-concat the message contents.
+        `tokenizer` is injectable so this is unit-testable without loading a model."""
+        tok = tokenizer if tokenizer is not None else self._tok
+        if self.use_chat_template and tok is not None and hasattr(tok, "apply_chat_template"):
+            return tok.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
+        return "\n".join((m.get("content") or "") for m in messages)
+
+    def resolve_params(self, params=None) -> dict:
+        """Merge default + per-call params (call overrides). Offline/unit-testable core."""
+        return {**self.default_params, **(params or {})}
+
+    def complete(self, messages, params=None) -> MLXResponse:
+        model, tok = self._ensure_loaded()
+        from mlx_lm import generate
+        prompt = self.build_prompt(messages, tokenizer=tok)
+        merged = self.resolve_params(params)
+        text = generate(model, tok, prompt=prompt, **merged)
+        return MLXResponse(text)

--- a/tests/test_mlx_caller.py
+++ b/tests/test_mlx_caller.py
@@ -1,0 +1,46 @@
+"""Tests for MLXCaller (issue #35) — prompt building (template vs raw), param merge, lazy load.
+Offline: a fake tokenizer is injected so build_prompt is testable without mlx-lm or a model."""
+from promptchain.utils.mlx_caller import MLXCaller, MLXResponse
+
+
+class _FakeTok:
+    def apply_chat_template(self, messages, add_generation_prompt=True, tokenize=False):
+        assert add_generation_prompt is True and tokenize is False
+        return "TEMPLATED:" + "|".join(m["content"] for m in messages)
+
+
+MSGS = [{"role": "system", "content": "S"}, {"role": "user", "content": "hi"}]
+
+
+def test_build_prompt_uses_chat_template():
+    c = MLXCaller("m", use_chat_template=True)
+    assert c.build_prompt(MSGS, tokenizer=_FakeTok()) == "TEMPLATED:S|hi"
+
+
+def test_build_prompt_raw_when_disabled():
+    c = MLXCaller("m", use_chat_template=False)
+    assert c.build_prompt(MSGS, tokenizer=_FakeTok()) == "S\nhi"
+
+
+def test_build_prompt_raw_when_no_template_support():
+    c = MLXCaller("m", use_chat_template=True)
+    assert c.build_prompt(MSGS, tokenizer=object()) == "S\nhi"  # tokenizer lacks apply_chat_template
+
+
+def test_resolve_params_call_overrides_instance():
+    c = MLXCaller("m", default_params={"max_tokens": 256, "temp": 0.2})
+    assert c.resolve_params({"temp": 0.0}) == {"max_tokens": 256, "temp": 0.0}
+
+
+def test_lazy_no_load_on_construct():
+    c = MLXCaller("/nonexistent")
+    assert c._model is None and c._tok is None
+
+
+def test_response_defaults():
+    r = MLXResponse("hello")
+    assert r.text == "hello" and r.usage == {}
+
+
+def test_response_none_text_safe():
+    assert MLXResponse(None).text == ""


### PR DESCRIPTION
Implements #35. Runs original/un-quantized HF weights on the Mac Studio via mlx_lm (load+generate), in-process + Metal. Naked — no litellm/ollama; the only normalization is the chat template, applied explicitly. Tool-calling via merged tool_normalization. Sibling to LlamaCppCaller (#34): MLX=original weights on the Mac, llama.cpp=crushed GGUF on the Mac. Lazy/optional mlx-lm dep; opt-in.

7 offline tests (template vs raw prompt, param merge, lazy, response). Closes #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)