### PR TITLE
feat: validity_stats + promptchain.validity sub-package (statistics + OKF instruction set)

### DIFF
--- a/docs/validity_stats_reference.md
+++ b/docs/validity_stats_reference.md
@@ -1,0 +1,70 @@
+# validity_stats — statistical inference reference
+
+The formulas behind `promptchain/utils/validity_stats.py`. Pairs with `validity_suite` (procedural
+checks). Use this to pick the RIGHT measure for your data shape so any inference you draw is sound.
+
+## Decision guide — which test?
+
+```text
+outcome type      pairing        -> correct significance test
+----------------  -------------  --------------------------------------------
+pass/fail (binary) PAIRED         -> McNemar's test         <-- OUR case; use compare_paired_binary()
+pass/fail (binary) unpaired       -> chi-square / Fisher's exact
+score (continuous) PAIRED         -> paired t / Wilcoxon signed-rank (if non-normal)
+score (continuous) unpaired       -> Welch's t / Mann-Whitney U (if non-normal)
+3+ arms, paired    (omnibus)      -> Friedman test, then post-hoc + correction
+```
+Always pair a p-value with an **effect size** and a **confidence interval**; when comparing K arms,
+apply a **multiple-comparison correction**; before trusting a null, check **power/MDE**.
+
+## Significance tests
+
+| Measure | Formula | Use when | Prevents |
+|---|---|---|---|
+| **McNemar** | χ² = (\|n01−n10\|−1)² / (n01+n10), df=1 | paired pass/fail (same items) | t-test on paired binary → overstated significance (Dietterich 1998) |
+| Welch's t | t = (x̄₁−x̄₂)/√(s₁²/n₁+s₂²/n₂) | unpaired continuous, unequal var | Student's-t → inflated Type-I error |
+| Wilcoxon signed-rank | signed ranks of paired diffs | paired ordinal / non-normal | paired-t assuming normality |
+| Mann-Whitney U | rank-sum of two groups | unpaired non-normal | t-test on skewed data |
+| Friedman | ranks across K paired arms | 3+ arms omnibus | many pairwise tests with no global check |
+
+## Effect size (magnitude — report ALONGSIDE p)
+
+| Measure | Formula | Note |
+|---|---|---|
+| **Cohen's h** (proportions) | h = 2·asin(√p₁) − 2·asin(√p₂) | 0.2 small · 0.5 med · 0.8 large; accounts for the ceiling (90→95 ≠ 50→55) |
+| Cohen's d (continuous) | (x̄₁−x̄₂)/pooled_sd | 0.2 / 0.5 / 0.8 |
+| Odds ratio | (p₁/(1−p₁))/(p₂/(1−p₂)) | "likelihood multiplier" |
+
+## Uncertainty (never report a bare mean)
+
+| Measure | Note |
+|---|---|
+| **Wilson score CI** | gold standard for pass-RATES; Wald interval gives impossible >100%/<0% near the edges |
+| Bootstrap CI | assumption-free (percentile of resamples); for custom metrics with no closed form |
+| Standard error | SE = s/√N — the CI/significance building block |
+
+## Multiple comparisons (K arms/scenarios)
+
+P(≥1 false positive) = 1 − (1−α)^K. Correct it:
+- **Holm-Bonferroni** — controls Family-Wise Error Rate (want *zero* false positives). Step-down.
+- Benjamini-Hochberg (BH) — controls False Discovery Rate (tolerate a small % of false positives for more power; exploratory).
+
+## Power & sample size
+
+- **Power (1−β)**: probability of detecting a real effect. Target ≥ 0.80.
+- **Minimum Detectable Effect**: MDE ≈ (z_{α/2}+z_β)·√(2p(1−p)/n). If your delta < MDE, the eval is too small to see it.
+- **Type-M error (Card 2020)**: underpowered evals *exaggerate* the effects that happen to pass p<0.05 — so an underpowered "significant" result is untrustworthy in both existence AND magnitude.
+
+## Reliability (when a judge/metric is in the loop)
+
+- **Cohen's κ** = (p_o − p_e)/(1 − p_e) — agreement corrected for chance (judge vs gold, or two judges). Relevant when using an LLM-as-critic: if κ ≈ 0 the judge is no better than chance.
+- ICC(2,1)/(3,1) — absolute agreement across raters (detects a consistently harsher judge). (scipy/pingouin.)
+
+## Priority for the library
+MUST: McNemar · Wilson CI · Holm-Bonferroni · MDE/power · Cohen's h/d.
+NICE: bootstrap CI · Wilcoxon/Mann-Whitney/Friedman · Cohen's κ / ICC.
+
+## References
+Dietterich (1998) *Approximate Statistical Tests for Comparing Supervised Classification Learning Algorithms*;
+Card et al. (2020) *With Little Power Comes Great Responsibility*; Cohen (1988) *Statistical Power Analysis*;
+Demsar (2006) *Statistical Comparisons of Classifiers over Multiple Data Sets*; Dodge et al. (2019) *Show Your Work*.

--- a/promptchain/utils/validity_stats.py
+++ b/promptchain/utils/validity_stats.py
@@ -1,0 +1,170 @@
+"""validity_stats — the STATISTICAL INFERENCE layer for validity_suite (issue #40).
+
+validity_suite asserts PROCEDURAL validity (did-it-fire, no-regression, harness-faithful...). This
+module answers the other half: **is an observed difference statistically STRONG or WEAK?** It ships the
+must-have measures so any comparison we bless is sound. Stdlib-first; scipy is an OPTIONAL lazy import
+(only for the rank tests). Each function documents its FORMULA, the CONDITION under which it's correct,
+and the MISTAKE it prevents.
+
+THE ONE THAT MATTERS MOST FOR US: our experiments compare the SAME scenarios base-vs-treatment with
+pass/fail outcomes = PAIRED BINARY data. The correct test is **McNemar's** (Dietterich 1998), NOT a
+t-test on scores (which ignores the pairing and overstates significance). Use `compare_paired_binary`.
+
+Refs: Dietterich (1998) approximate tests for comparing classifiers; Card et al. (2020) With Little
+Power (power/Type-M); Cohen (1988) effect sizes d/h; Demsar (2006) comparisons over multiple datasets.
+"""
+import math
+import statistics
+
+
+# --------------------------------------------------------- helpers (inverse normal for power/MDE)
+def _probit(p):
+    """Inverse standard-normal CDF (Acklam's rational approximation). z such that Phi(z)=p."""
+    if not 0.0 < p < 1.0:
+        raise ValueError("p must be in (0,1)")
+    a = [-3.969683028665376e+01, 2.209460984245205e+02, -2.759285104469687e+02, 1.383577518672690e+02, -3.066479806614716e+01, 2.506628277459239e+00]
+    b = [-5.447609879822406e+01, 1.615858368580409e+02, -1.556989798598866e+02, 6.680131188771972e+01, -1.328068155288572e+01]
+    c = [-7.784894002430293e-03, -3.223964580411365e-01, -2.400758277161838e+00, -2.549732539343734e+00, 4.374664141464968e+00, 2.938163982698783e+00]
+    d = [7.784695709041462e-03, 3.224671290700398e-01, 2.445134137142996e+00, 3.754408661907416e+00]
+    plow, phigh = 0.02425, 1 - 0.02425
+    if p < plow:
+        q = math.sqrt(-2 * math.log(p)); return (((((c[0]*q+c[1])*q+c[2])*q+c[3])*q+c[4])*q+c[5]) / ((((d[0]*q+d[1])*q+d[2])*q+d[3])*q+1)
+    if p > phigh:
+        q = math.sqrt(-2 * math.log(1-p)); return -(((((c[0]*q+c[1])*q+c[2])*q+c[3])*q+c[4])*q+c[5]) / ((((d[0]*q+d[1])*q+d[2])*q+d[3])*q+1)
+    q = p - 0.5; r = q*q
+    return (((((a[0]*r+a[1])*r+a[2])*r+a[3])*r+a[4])*r+a[5])*q / (((((b[0]*r+b[1])*r+b[2])*r+b[3])*r+b[4])*r+1)
+
+
+def _chi2_sf_df1(x):
+    """Survival function of chi-square with df=1 (the McNemar p-value). = erfc(sqrt(x/2))."""
+    return math.erfc(math.sqrt(x / 2.0)) if x > 0 else 1.0
+
+
+# --------------------------------------------------------- MUST-HAVE 1: McNemar (paired binary)
+def mcnemar(base_correct, treatment_correct, continuity=True):
+    """McNemar's test — the CORRECT significance test for PAIRED BINARY outcomes (same items, pass/fail
+    under base vs treatment). Formula (with continuity correction): chi2 = (|n01-n10|-1)^2 / (n01+n10),
+    p = chi2_sf(chi2, df=1). n01 = base wrong & treatment RIGHT (treatment wins), n10 = base right &
+    treatment WRONG (treatment loses). PREVENTS: using a t-test/chi-square that ignores the pairing and
+    overstates significance (Dietterich 1998)."""
+    n01 = sum(1 for b, t in zip(base_correct, treatment_correct) if (not b) and t)   # treatment fixes
+    n10 = sum(1 for b, t in zip(base_correct, treatment_correct) if b and (not t))   # treatment breaks
+    disc = n01 + n10
+    if disc == 0:
+        return {"stat": 0.0, "p": 1.0, "n01_treatment_wins": 0, "n10_treatment_breaks": 0,
+                "note": "no discordant pairs — the two arms are indistinguishable here"}
+    d = abs(n01 - n10) - (1 if continuity else 0)
+    chi2 = (d * d) / disc if d > 0 else 0.0
+    return {"stat": chi2, "p": _chi2_sf_df1(chi2), "n01_treatment_wins": n01, "n10_treatment_breaks": n10,
+            "direction": "treatment better" if n01 > n10 else ("treatment worse" if n10 > n01 else "tie")}
+
+
+# --------------------------------------------------------- MUST-HAVE 2: Wilson score CI (proportions)
+def wilson_ci(k, n, conf=0.95):
+    """Wilson score interval for a pass-RATE (k passes of n). The gold standard for binomial proportions.
+    PREVENTS: the naive Wald interval (p +/- 1.96*SE) producing impossible bounds (<0 or >1) near 0%/100%."""
+    if n == 0:
+        return (0.0, 1.0)
+    z = _probit(1 - (1 - conf) / 2); ph = k / n; d = 1 + z*z/n
+    center = (ph + z*z/(2*n)) / d
+    margin = z * math.sqrt(ph*(1-ph)/n + z*z/(4*n*n)) / d
+    return (max(0.0, center - margin), min(1.0, center + margin))
+
+
+# --------------------------------------------------------- MUST-HAVE 3: multiple-comparison correction
+def holm_bonferroni(pvalues, alpha=0.05):
+    """Holm-Bonferroni step-down correction controlling FAMILY-WISE error rate across K comparisons.
+    PREVENTS: running K arms/scenarios and calling a chance winner significant (P(>=1 false pos) = 1-(1-a)^K).
+    Returns list of {index, p, threshold, reject} in the ORIGINAL order."""
+    idx = sorted(range(len(pvalues)), key=lambda i: pvalues[i]); k = len(pvalues)
+    out = {i: None for i in range(k)}; still = True
+    for rank, i in enumerate(idx):
+        thr = alpha / (k - rank)
+        rej = still and pvalues[i] <= thr
+        if not rej:
+            still = False
+        out[i] = {"index": i, "p": pvalues[i], "threshold": thr, "reject": rej}
+    return [out[i] for i in range(k)]
+
+
+# --------------------------------------------------------- MUST-HAVE 4: power / minimum detectable effect
+def min_detectable_effect(n, p_baseline, alpha=0.05, power=0.8):
+    """Minimum Detectable Effect for a two-proportion comparison at sample size n. Approx:
+    MDE ~= (z_alpha/2 + z_power) * sqrt(2*p*(1-p)/n). PREVENTS: claiming (or chasing) a delta your eval
+    set is too small to see — underpowered evals give Type-M (magnitude) errors (Card et al. 2020)."""
+    za = _probit(1 - alpha/2); zb = _probit(power); p = p_baseline
+    return (za + zb) * math.sqrt(2 * p * (1 - p) / max(n, 1))
+
+
+# --------------------------------------------------------- MUST-HAVE 5: effect sizes
+def cohens_h(p1, p2):
+    """Effect size for two PROPORTIONS: h = 2*asin(sqrt(p1)) - 2*asin(sqrt(p2)). |h|: 0.2 small, 0.5 med,
+    0.8 large. PREVENTS: treating a 90->95% gain as equal to 50->55% (h accounts for the ceiling)."""
+    return 2*math.asin(math.sqrt(p1)) - 2*math.asin(math.sqrt(p2))
+
+
+def cohens_d(a, b):
+    """Effect size for two CONTINUOUS samples: (mean_a - mean_b)/pooled_sd. |d|: 0.2 small, 0.5 med, 0.8 large."""
+    na, nb = len(a), len(b)
+    if na < 2 or nb < 2:
+        return 0.0
+    sp = math.sqrt(((na-1)*statistics.variance(a) + (nb-1)*statistics.variance(b)) / (na+nb-2)) or 1e-9
+    return (statistics.mean(a) - statistics.mean(b)) / sp
+
+
+# --------------------------------------------------------- NICE: bootstrap CI, kappa, rank tests
+def bootstrap_ci(data, statistic=None, n_resamples=2000, conf=0.95, seed=0):
+    """Assumption-free CI via percentile bootstrap. For custom metrics with no closed-form CI."""
+    import random
+    statistic = statistic or statistics.mean
+    rng = random.Random(seed); n = len(data)
+    if n == 0:
+        return (0.0, 0.0)
+    stats_ = sorted(statistic([data[rng.randrange(n)] for _ in range(n)]) for _ in range(n_resamples))
+    lo = stats_[int((1-conf)/2 * n_resamples)]; hi = stats_[int((1+conf)/2 * n_resamples) - 1]
+    return (lo, hi)
+
+
+def cohens_kappa(rater1, rater2):
+    """Inter-rater agreement (e.g. two judges / a judge vs gold): kappa = (po - pe)/(1 - pe), correcting
+    for chance agreement. PREVENTS: trusting a judge/metric whose agreement is no better than chance."""
+    n = len(rater1) or 1; cats = set(rater1) | set(rater2)
+    po = sum(1 for a, b in zip(rater1, rater2) if a == b) / n
+    pe = sum((sum(1 for x in rater1 if x == c)/n) * (sum(1 for x in rater2 if x == c)/n) for c in cats)
+    return (po - pe) / (1 - pe) if pe < 1 else 1.0
+
+
+def wilcoxon_signed_rank(a, b):
+    """Paired NON-parametric test (ordinal/non-normal paired scores). Lazy scipy."""
+    from scipy import stats
+    r = stats.wilcoxon(a, b)
+    return {"stat": float(r.statistic), "p": float(r.pvalue)}
+
+
+def mann_whitney_u(a, b):
+    """Unpaired NON-parametric test (independent groups, non-normal). Lazy scipy."""
+    from scipy import stats
+    r = stats.mannwhitneyu(a, b, alternative="two-sided")
+    return {"stat": float(r.statistic), "p": float(r.pvalue)}
+
+
+# --------------------------------------------------------- the convenience: paired pass/fail, done right
+def compare_paired_binary(base_correct, treatment_correct, alpha=0.05):
+    """THE function for our data shape: base vs treatment pass/fail on the SAME scenarios. Runs McNemar
+    (correct test) + Wilson CIs on each pass-rate + Cohen's h (effect) + a STRONG/WEAK/INCONCLUSIVE verdict."""
+    n = len(base_correct)
+    bp = sum(bool(x) for x in base_correct); tp = sum(bool(x) for x in treatment_correct)
+    mc = mcnemar(base_correct, treatment_correct)
+    p1, p2 = bp/n, tp/n
+    h = cohens_h(p2, p1)
+    sig = mc["p"] < alpha
+    if not sig:
+        verdict = "INCONCLUSIVE (not significant — likely noise or underpowered)"
+    elif abs(h) < 0.2:
+        verdict = "WEAK (significant but trivial effect size)"
+    else:
+        verdict = f"STRONG ({'improvement' if p2>p1 else 'regression'})"
+    return {"n": n, "base_rate": p1, "treatment_rate": p2,
+            "base_ci": wilson_ci(bp, n), "treatment_ci": wilson_ci(tp, n),
+            "mcnemar": mc, "cohens_h": h, "significant": sig, "verdict": verdict,
+            "mde_at_this_n": min_detectable_effect(n, p1, alpha)}

--- a/promptchain/validity/__init__.py
+++ b/promptchain/validity/__init__.py
@@ -1,0 +1,42 @@
+"""promptchain.validity — the agent-facing EXPERIMENT-VALIDITY toolkit (issue #40).
+
+Brings the validity work "home" under one cohesive, agent-specific namespace. Two layers:
+  • PROCEDURAL checks (validity_suite): technique_fired · no_regression · harness_faithful ·
+    no_silent_defaults · variance_bounded · negative_control · monotonic · ValiditySuite runner.
+  • STATISTICAL inference (validity_stats): mcnemar · wilson_ci · holm_bonferroni · min_detectable_effect
+    · cohens_h/d · cohens_kappa · bootstrap_ci · compare_paired_binary · (lazy scipy) rank tests.
+
+Plus an OKF knowledge bundle at `promptchain/validity/okf/` — the AGENT-READABLE instruction set
+(when/why to run each check), so an agent can both CALL the checks and READ the reasoning. Point an OKF
+consumer at that dir. `okf_path()` returns it.
+
+The implementations live in promptchain.utils.{validity_suite,validity_stats}; this package is the
+convenient front door. Run the checks BEFORE trusting any experiment's aggregate score.
+"""
+import os
+
+from promptchain.utils.validity_suite import (  # procedural
+    Check, ValiditySuite,
+    technique_fired, no_regression, above_noise, harness_faithful,
+    no_silent_defaults, variance_bounded, negative_control, monotonic,
+)
+from promptchain.utils.validity_stats import (  # statistical
+    mcnemar, wilson_ci, holm_bonferroni, min_detectable_effect,
+    cohens_h, cohens_d, cohens_kappa, bootstrap_ci, compare_paired_binary,
+    wilcoxon_signed_rank, mann_whitney_u,
+)
+
+
+def okf_path():
+    """Absolute path to the OKF instruction-set bundle (the agent-readable validity knowledge)."""
+    return os.path.join(os.path.dirname(__file__), "okf")
+
+
+__all__ = [
+    "Check", "ValiditySuite",
+    "technique_fired", "no_regression", "above_noise", "harness_faithful",
+    "no_silent_defaults", "variance_bounded", "negative_control", "monotonic",
+    "mcnemar", "wilson_ci", "holm_bonferroni", "min_detectable_effect",
+    "cohens_h", "cohens_d", "cohens_kappa", "bootstrap_ci", "compare_paired_binary",
+    "wilcoxon_signed_rank", "mann_whitney_u", "okf_path",
+]

--- a/promptchain/validity/okf/checks/above-noise.md
+++ b/promptchain/validity/okf/checks/above-noise.md
@@ -1,0 +1,14 @@
+---
+type: Assertion
+title: Above noise (N-run significance) — the ground floor
+description: n=1 proves nothing; a delta inside the base's own run-to-run variance is not a result.
+tags: [validity, statistics, significance]
+---
+
+The FIRST and most fundamental check. Never conclude from a single run: run the same experiment N≥3–5
+times to get a mean AND a variance, and check the BASE's own variance first — a "−5" delta is meaningless
+if the base swings ±5. Case: "strategies hurt 84→79→75" was temp-0.2 noise; the base itself flipped
+scenarios. Grounded in Henderson (Deep RL that Matters), Dodge (Show Your Work), Card (With Little Power).
+
+Function: `promptchain.validity.above_noise(control_scores, treatment_scores)`. For paired pass/fail use
+[mcnemar](/tests/mcnemar.md), not a t-test.

--- a/promptchain/validity/okf/checks/harness-faithful.md
+++ b/promptchain/validity/okf/checks/harness-faithful.md
@@ -1,0 +1,13 @@
+---
+type: Assertion
+title: Harness faithful (positive control)
+description: A known-good model must reproduce its known score through your eval rig, else the rig is broken.
+tags: [validity, harness, positive-control]
+---
+
+Before trusting ANY number, run a known-good model through the SAME rig. If it doesn't reproduce its
+known score within tolerance, the **harness is broken** and every result is suspect. Case: glm-5.2 scored
+70 natively but 40 through a naked eval server — the rig capped everyone at 40, so "the technique doesn't
+help" was really "the rig is broken". Grounded in Breck et al. ML Test Score (Infra Test 2).
+
+Function: `promptchain.validity.harness_faithful(known_score, expected_score)`.

--- a/promptchain/validity/okf/checks/no-regression.md
+++ b/promptchain/validity/okf/checks/no-regression.md
@@ -1,0 +1,12 @@
+---
+type: Assertion
+title: No regression on correct baseline items
+description: An intervention must not make items the baseline got right worse; aggregate gains can hide regressions.
+tags: [validity, regression]
+---
+
+A technique can raise the aggregate while silently breaking items the baseline got right. Compare
+item-level correctness, not averages: count items where base=correct AND treatment=wrong. Case: a critique
+that turned a correct restraint into a hallucination — the "helper" LOWERED a correct base.
+
+Function: `promptchain.validity.no_regression(control_correct, treatment_correct)`. See TFX ModelValidator.

--- a/promptchain/validity/okf/checks/technique-fired.md
+++ b/promptchain/validity/okf/checks/technique-fired.md
@@ -1,0 +1,15 @@
+---
+type: Assertion
+title: Technique actually fired (no-op detection)
+description: Treatment output identical to control means the intervention never ran — a non-result.
+tags: [validity, no-op]
+---
+
+If the treatment arm's per-item outputs are (near-)identical to control, the technique **did not fire**
+(a config/wiring bug, a gate that never triggered). That is a NON-result — not evidence the technique
+has no effect. Case: a gated critique whose gate never fired → treatment byte-identical to base → looked
+like "critique fails" but the critique simply never ran. Related: [validation-workflow](/validation-workflow.md).
+
+Function: `promptchain.validity.technique_fired(control_outputs, treatment_outputs)`.
+Deeper: also assert the intervention's STEP fired via the pipeline trace (PromptChain `trail`/`step_outputs`),
+and use a "strength knob" (`monotonic`) — a flat metric across the knob means a no-op.

--- a/promptchain/validity/okf/index.md
+++ b/promptchain/validity/okf/index.md
@@ -1,0 +1,16 @@
+# Experiment Validity — OKF knowledge bundle
+
+The agent-readable instruction set for validating ML/LLM experiments before trusting a score.
+Pairs with the executable checks in `promptchain.validity`. Read [validation-workflow](/validation-workflow.md) first.
+
+## Procedural checks (`checks/`)
+- [technique-fired](/checks/technique-fired.md) — did the intervention actually run?
+- [no-regression](/checks/no-regression.md) — did it break correct baseline items?
+- [harness-faithful](/checks/harness-faithful.md) — does a known-good model reproduce its known score?
+- [above-noise](/checks/above-noise.md) — is the delta bigger than run-to-run variance?
+
+## Statistical measures (`tests/`)
+- [mcnemar](/tests/mcnemar.md) — the correct test for paired pass/fail
+- [wilson-ci](/tests/wilson-ci.md) — confidence interval for a pass-rate
+- [holm-bonferroni](/tests/holm-bonferroni.md) — correct for comparing many arms
+- [power-mde](/tests/power-mde.md) — can the eval even detect this effect?

--- a/promptchain/validity/okf/log.md
+++ b/promptchain/validity/okf/log.md
@@ -1,0 +1,5 @@
+# Update log
+
+- 2026-07-05 — Bundle created. Procedural checks + statistical measures authored from the
+  2026-07 tool-calling investigation (single-run deltas, technique-never-fired, critique-lowered-base,
+  silent parse-default, harness capping glm at 40-vs-70) and the deep-research survey.

--- a/promptchain/validity/okf/tests/holm-bonferroni.md
+++ b/promptchain/validity/okf/tests/holm-bonferroni.md
@@ -1,0 +1,12 @@
+---
+type: StatisticalTest
+title: Holm-Bonferroni (multiple comparisons)
+description: Correct p-values when comparing many arms/scenarios, else a chance winner looks significant.
+tags: [statistics, multiple-comparisons]
+---
+
+Comparing K arms inflates the false-positive rate: P(≥1 false positive) = 1 − (1−α)^K. **Holm-Bonferroni**
+(step-down) controls the family-wise error rate. Use it for any multi-arm leaderboard or prompt sweep.
+(Benjamini-Hochberg controls the false-discovery rate for exploratory work.)
+
+Function: `promptchain.validity.holm_bonferroni(pvalues, alpha=0.05)`.

--- a/promptchain/validity/okf/tests/mcnemar.md
+++ b/promptchain/validity/okf/tests/mcnemar.md
@@ -1,0 +1,14 @@
+---
+type: StatisticalTest
+title: McNemar's test (paired pass/fail)
+description: The correct significance test for two arms scored on the SAME items with binary outcomes.
+tags: [statistics, paired, binary]
+---
+
+When comparing base vs treatment on the SAME scenarios with pass/fail outcomes (our usual shape), the
+correct test is **McNemar's**, not a t-test (which ignores the pairing and overstates significance —
+Dietterich 1998). χ² = (|n01−n10|−1)²/(n01+n10), df=1, over the discordant pairs (n01 = base wrong &
+treatment right; n10 = the reverse).
+
+Function: `promptchain.validity.mcnemar(base_correct, treatment_correct)` or the one-call
+`compare_paired_binary(...)` (McNemar + Wilson CIs + Cohen's h + STRONG/WEAK verdict).

--- a/promptchain/validity/okf/tests/power-mde.md
+++ b/promptchain/validity/okf/tests/power-mde.md
@@ -1,0 +1,12 @@
+---
+type: StatisticalTest
+title: Power & minimum detectable effect
+description: Can your eval set even detect the effect you're claiming? Underpowered evals lie both ways.
+tags: [statistics, power, sample-size]
+---
+
+Before trusting a delta (or a null), ask whether the eval is big enough to see it. Minimum Detectable
+Effect: MDE ≈ (z_{α/2}+z_β)·√(2p(1−p)/n). If your delta < MDE, the set is too small. Underpowered evals
+produce Type-M (magnitude) errors — "significant" results are exaggerated (Card et al. 2020).
+
+Function: `promptchain.validity.min_detectable_effect(n, p_baseline)`.

--- a/promptchain/validity/okf/tests/wilson-ci.md
+++ b/promptchain/validity/okf/tests/wilson-ci.md
@@ -1,0 +1,11 @@
+---
+type: StatisticalTest
+title: Wilson score confidence interval (proportions)
+description: The correct CI for a pass-RATE; never report a bare pass-rate without one.
+tags: [statistics, confidence-interval, proportions]
+---
+
+A pass-rate is an estimate with uncertainty — always report a CI. Use the **Wilson score interval** for
+proportions; the naive Wald interval (p ± 1.96·SE) gives impossible bounds (<0 or >1) near 0%/100%.
+
+Function: `promptchain.validity.wilson_ci(passes, n)`.

--- a/promptchain/validity/okf/validation-workflow.md
+++ b/promptchain/validity/okf/validation-workflow.md
@@ -1,0 +1,23 @@
+---
+type: Workflow
+title: Validate an experiment before concluding
+description: The order to run validity checks in; an experiment number is a hypothesis, not a conclusion.
+tags: [validity, experiments, meta]
+---
+
+An experiment's aggregate score is a **hypothesis to verify, not a conclusion**. Before reporting
+"technique X scored Y", run these — if any fails, investigate; do NOT conclude.
+
+1. **[above-noise](/checks/above-noise.md)** (ground floor) — N≥3–5 reps; a delta inside the base's own
+   variance is nothing. n=1 proves nothing.
+2. **[harness-faithful](/checks/harness-faithful.md)** — a known-good model must reproduce its known
+   score through your rig, else the rig is broken and all numbers are suspect.
+3. **[technique-fired](/checks/technique-fired.md)** — treatment byte-identical to control = the
+   intervention never ran (a non-result, not "no effect").
+4. **[no-regression](/checks/no-regression.md)** — the intervention must not make correct base items worse.
+5. **no-silent-defaults** — a parse/exception fallback must not quietly "pass".
+6. Pick the CORRECT statistical test for the data shape: paired pass/fail → [mcnemar](/tests/mcnemar.md);
+   report an effect size + a [wilson-ci](/tests/wilson-ci.md); comparing many arms → [holm-bonferroni](/tests/holm-bonferroni.md);
+   before trusting a null, check [power-mde](/tests/power-mde.md).
+
+Runnable: `promptchain.validity` (`ValiditySuite`, `compare_paired_binary`, ...).

--- a/tests/test_validity_namespace.py
+++ b/tests/test_validity_namespace.py
@@ -1,0 +1,36 @@
+"""The promptchain.validity sub-package: namespace re-exports + OKF bundle conformance (issue #40)."""
+import os
+import re
+from promptchain import validity as V
+
+
+def test_namespace_reexports_both_layers():
+    # procedural + statistical, one front door
+    for name in ("technique_fired", "no_regression", "harness_faithful", "ValiditySuite",
+                 "mcnemar", "wilson_ci", "holm_bonferroni", "compare_paired_binary", "okf_path"):
+        assert hasattr(V, name), f"promptchain.validity missing {name}"
+    assert callable(V.mcnemar) and callable(V.technique_fired)
+
+
+def test_okf_path_exists():
+    p = V.okf_path()
+    assert os.path.isdir(p) and os.path.isfile(os.path.join(p, "index.md"))
+
+
+def test_okf_bundle_is_spec_conformant():
+    p = V.okf_path()
+    # index.md and log.md MUST NOT have frontmatter (OKF spec §6/§7)
+    for f in ("index.md", "log.md"):
+        assert not open(os.path.join(p, f)).read().startswith("---"), f"{f} must have no frontmatter"
+    # every concept file MUST have a non-empty `type:` in YAML frontmatter (OKF §4.1)
+    concepts = 0
+    for root, _, files in os.walk(p):
+        for fn in files:
+            if fn in ("index.md", "log.md") or not fn.endswith(".md"):
+                continue
+            txt = open(os.path.join(root, fn)).read()
+            assert txt.startswith("---"), f"{fn} missing frontmatter"
+            m = re.search(r"^type:\s*(\S+)", txt, re.M)
+            assert m, f"{fn} missing required 'type:'"
+            concepts += 1
+    assert concepts >= 8  # workflow + 4 checks + 4 tests

--- a/tests/test_validity_stats.py
+++ b/tests/test_validity_stats.py
@@ -1,0 +1,67 @@
+"""Tests for validity_stats (issue #40) — known-value checks per statistical measure."""
+import math
+from promptchain.utils import validity_stats as vst
+
+
+def test_mcnemar_significant_improvement():
+    # treatment fixes 12, breaks 1 -> clearly significant improvement
+    base = [False]*12 + [True]*8
+    treat = [True]*12 + [False] + [True]*7
+    r = vst.mcnemar(base, treat)
+    assert r["n01_treatment_wins"] == 12 and r["n10_treatment_breaks"] == 1
+    assert r["p"] < 0.05 and r["direction"] == "treatment better"
+
+
+def test_mcnemar_no_discordant_is_null():
+    r = vst.mcnemar([True, False, True], [True, False, True])
+    assert r["p"] == 1.0  # identical -> indistinguishable
+
+
+def test_wilson_ci_bounds_valid_at_edges():
+    lo, hi = vst.wilson_ci(10, 10)      # 100% passes
+    assert 0.0 <= lo <= hi <= 1.0 and hi == 1.0 and lo > 0.6   # not the impossible >1 of Wald
+    lo0, hi0 = vst.wilson_ci(0, 20)
+    assert lo0 == 0.0 and 0.0 < hi0 < 0.3
+
+
+def test_holm_bonferroni_controls_fwer():
+    res = vst.holm_bonferroni([0.001, 0.04, 0.03, 0.9], alpha=0.05)
+    # smallest p rejected; the 0.9 never; step-down thresholds a/(k-rank)
+    assert res[0]["reject"] is True and res[3]["reject"] is False
+    assert res[0]["threshold"] == 0.05/4
+
+
+def test_min_detectable_effect_shrinks_with_n():
+    small = vst.min_detectable_effect(20, 0.5)
+    big = vst.min_detectable_effect(2000, 0.5)
+    assert small > big > 0   # bigger eval detects smaller effects
+
+
+def test_cohens_h_ceiling_effect():
+    # 90->95 should be a LARGER effect size than 50->55 (ceiling)
+    assert abs(vst.cohens_h(0.95, 0.90)) > abs(vst.cohens_h(0.55, 0.50))
+
+
+def test_cohens_d_known():
+    d = vst.cohens_d([2,2,2,2], [0,0,0,0])   # mean diff 2, ~0 within-var
+    assert d > 3
+
+
+def test_cohens_kappa_perfect_and_chance():
+    assert vst.cohens_kappa(["a","b","a","b"], ["a","b","a","b"]) == 1.0     # perfect
+    k = vst.cohens_kappa(["a","a","b","b"], ["a","b","a","b"])               # chance-ish
+    assert -0.6 < k < 0.6
+
+
+def test_bootstrap_ci_contains_mean():
+    lo, hi = vst.bootstrap_ci([10,11,9,10,12,8,10,11], conf=0.95)
+    assert lo <= 10 <= hi
+
+
+def test_compare_paired_binary_end_to_end():
+    base = [False]*12 + [True]*8
+    treat = [True]*12 + [False] + [True]*7
+    r = vst.compare_paired_binary(base, treat)
+    assert r["significant"] and "STRONG" in r["verdict"]
+    assert r["treatment_rate"] > r["base_rate"]
+    assert 0.0 <= r["base_ci"][0] <= r["base_ci"][1] <= 1.0


### PR DESCRIPTION
Implements #40. Adds the statistical inference layer (McNemar — the correct paired-pass/fail test we were doing wrong, Wilson CI, Holm-Bonferroni, MDE/power, Cohen's h/d/kappa, bootstrap, lazy-scipy rank tests) and brings validity **home** as `promptchain.validity` — a cohesive agent-specific sub-package re-exporting the procedural + statistical layers PLUS an **OKF knowledge bundle** (`promptchain/validity/okf/`): the agent-readable instruction set (workflow + per-check/per-test concept files, spec-conformant). Reference doc included.

21 tests (10 stats known-value + 3 namespace/OKF-conformance + the 10 procedural from #39 unchanged). Closes #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)