### PR TITLE
feat: surface OKFLoader top-level (from promptchain import OKFLoader)

### DIFF
--- a/promptchain/__init__.py
+++ b/promptchain/__init__.py
@@ -11,9 +11,14 @@ from .utils.docker_executor import DockerExecutor
 from .utils.test_loop_chain import MicroPromptChain, LoopResult, LocalExecutor
 from .utils.autoresearch import AutoResearch, ResearchResult, auto_research
 from .utils.ralph_chain import RalphChain, RalphResult
+from .utils.okf_loader import OKFLoader, okf_step, okf_agentic_context, okf_reader_tool
 
 __all__ = [
     'PromptChain',
+    'OKFLoader',
+    'okf_step',
+    'okf_agentic_context',
+    'okf_reader_tool',
     'PromptEngineer',
     'load_prompts',
     'get_prompt_by_name',


### PR DESCRIPTION
Follow-up to #43. Exports OKFLoader + okf_step/okf_agentic_context/okf_reader_tool at the package top level so OKF import is a first-class `from promptchain import OKFLoader`, alongside PromptChain — not buried in utils.

🤖 Generated with [Claude Code](https://claude.com/claude-code)