### PR TITLE
ci: auto-version from conventional commits (setuptools_scm)

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -1,0 +1,28 @@
+name: auto-version
+
+# Auto-version on merge to main. PromptChain uses setuptools_scm (version derives from git tags), so
+# creating a tag IS the release. This reads CONVENTIONAL COMMITS since the last tag and creates the next
+# semver tag: feat: -> minor, fix: -> patch, "BREAKING CHANGE"/! -> major. Merges with no such commit
+# create no tag (default_bump: false). See docs/RELEASING.md.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  autotag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0            # full history so the tagger can read commits since the last tag
+      - name: Create version tag from conventional commits
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: false       # only bump on feat/fix/BREAKING — no tag on docs/chore/ci
+          release_branches: main
+          tag_prefix: v

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,26 @@
+# Releasing / versioning
+
+PromptChain uses **setuptools_scm** — the package version is derived from the latest **git tag**
+(`pyproject.toml` → `[tool.setuptools_scm]`, `write_to = promptchain/_version.py`). There is no version
+number to hand-edit; **creating a tag is the release.**
+
+## Automatic (default)
+The `.github/workflows/auto-version.yml` action runs on every merge to `main`, reads the **conventional
+commits** since the last tag, and creates the next semver tag:
+
+| commit prefix | bump | example |
+|---|---|---|
+| `feat:` | minor | v0.7.0 → v0.8.0 |
+| `fix:` | patch | v0.7.0 → v0.7.1 |
+| `feat!:` / `BREAKING CHANGE:` in body | major | v0.7.0 → v1.0.0 (pre-1.0: still a minor bump under semver 0.x) |
+| `docs:` / `chore:` / `ci:` only | none | no tag created |
+
+So: **write conventional commit messages** and versioning happens on merge. Between tags, setuptools_scm
+reports a dev version like `0.7.1.devN+g<sha>`.
+
+## Manual (catch-up or override)
+```bash
+git tag -a v0.8.0 origin/main -m "release notes"
+git push origin v0.8.0
+```
+`v0.7.0` was cut manually as the catch-up baseline for the naked-callers + validity + OKF batch.


### PR DESCRIPTION
Sets up proper auto-versioning. PromptChain uses setuptools_scm (version = latest git tag), so a tag is the release. This action reads conventional commits on merge to main and cuts the next semver tag (feat→minor, fix→patch, BREAKING→major; docs/chore/ci → none). Baseline v0.7.0 was cut manually for the naked-callers + validity + OKF batch. + docs/RELEASING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)