### PR TITLE
feat(tui): interactive /model chooser (Ctrl+N) + per-step models doc

### DIFF
--- a/docs/per_step_models.md
+++ b/docs/per_step_models.md
@@ -1,0 +1,105 @@
+# Per-Step Models — give each chain step its own model (and params)
+
+PromptChain lets **every model-step run on its own model**. You do this by passing a
+`models=[...]` list that lines up 1:1 with your model-instruction steps. As the chain
+executes, an internal `model_index` counter walks the list — step 1 uses `models[0]`,
+step 2 uses `models[1]`, and so on.
+
+This is the mechanism behind `models=["openai/gpt-4o", "anthropic/claude-opus-4-8", ...]`.
+It's distinct from `model_management` (which governs **VRAM load/unload** of Ollama models
+between steps — see [`model_management.md`](model_management.md)). Per-step models is purely
+*which model answers which step*.
+
+## The shape
+
+```python
+from promptchain import PromptChain
+
+chain = PromptChain(
+    models=[
+        "openai/gpt-4o",                          # step 1's model (plain string)
+        {                                          # step 2: its own model AND its own params
+            "name": "anthropic/claude-opus-4-8",
+            "params": {"temperature": 0.2, "max_tokens": 2000},
+        },
+        "ollama/qwen2.5:7b",                       # step 3's model
+    ],
+    instructions=[
+        "Brainstorm ideas about: {input}",         # → openai/gpt-4o
+        "Critique the ideas: {input}",             # → claude-opus-4-8 (temp 0.2)
+        "Write the final code: {input}",           # → ollama/qwen2.5:7b
+    ],
+)
+```
+
+Each entry in `models` can be:
+
+- a **plain string** — `"openai/gpt-4o"` → that step runs on this model with default params.
+- a **dict** — `{"name": "...", "params": {...}}` → that step gets its **own model and its
+  own model_params** (temperature, max_tokens, etc.). The params are passed through to the
+  LiteLLM call for that step only.
+
+## The three rules
+
+1. **Count must match.** `len(models)` must equal the number of **model steps** — i.e.
+   instructions that are *not* a Python function, *not* an `AgenticStepProcessor`, and *not*
+   a `ChainCall`. Those step types are skipped in the count (functions run no LLM; agentic
+   steps set their model separately via `model_name`). Mismatch raises a `ValueError` at
+   construction time.
+
+2. **One model → repeated for all.** If you pass a **single** model but multiple model
+   instructions, PromptChain auto-expands it so every step uses that one model:
+
+   ```python
+   PromptChain(
+       models=["openai/gpt-4o-mini"],             # one model
+       instructions=["Step 1: {input}", "Step 2: {input}", "Step 3: {input}"],
+   )  # → all three steps run on gpt-4o-mini
+   ```
+
+3. **Order is execution order.** The model list is consumed in sequence by `model_index`,
+   which resets at the start of each `process_prompt` / `process_prompt_async` run. The Nth
+   model step always pulls the Nth entry — so keep `models` and `instructions` aligned.
+
+## Agentic steps set their model separately
+
+An `AgenticStepProcessor` does **not** draw from the `models` list. It carries its own model
+(via `model_name=`, plus `fallback_model=` for two-tier routing). That's why agentic steps are
+excluded from the count in rule 1. A mixed chain looks like:
+
+```python
+chain = PromptChain(
+    models=["openai/gpt-4o"],                      # ONE entry — for the single string step below
+    instructions=[
+        "Summarize: {input}",                      # ← consumes models[0]
+        AgenticStepProcessor(                       # ← brings its OWN model, NOT from models[]
+            objective="Research and verify the summary",
+            model_name="gemini/gemini-2.5-pro",
+            fallback_model="gemini/gemini-1.5-flash-8b",
+        ),
+    ],
+)
+```
+
+## Source of truth (code)
+
+- Constructor — `promptchain/utils/promptchaining.py:286-324`
+  - per-entry string/dict handling: `:308-314`
+  - single-model auto-repeat: `:303-305`
+  - count validation + `ValueError`: `:318-324`
+- Per-step selection at execution — `promptchain/utils/promptchaining.py:1669-1671`
+  ```python
+  model = self.models[self.model_index]
+  step_model_params = self.model_params[self.model_index]
+  self.model_index += 1   # advance to the next model step
+  ```
+- `model_index` reset per run — `:481-483` (`reset_model_index`), called at `:751`.
+
+## Related
+
+- [`recipe-models-and-tool-calling`](../recipes) — *which* model string to pick per step
+  (provider prefixes, tool-calling capability matrix).
+- [`model_management.md`](model_management.md) — VRAM-aware load/unload of Ollama models
+  between steps (a different concern from per-step model selection).
+- Two-tier routing (`AgenticStepProcessor` `enable_two_tier_routing=True`) — per-step primary
+  + cheap fallback model inside an agentic step.

--- a/promptchain/cli/command_handler.py
+++ b/promptchain/cli/command_handler.py
@@ -71,6 +71,11 @@ COMMAND_REGISTRY: Dict[str, Dict[str, str]] = {
         "description": "Delete a saved session",
         "usage": "/session delete <name>",
     },
+    # Model chooser
+    "/model": {
+        "description": "Open the model chooser (local · cloud · OpenAI/Gemini)",
+        "usage": "/model",
+    },
     # Agent commands
     "/agent": {"description": "Show current agent info", "usage": "/agent"},
     "/agent list": {

--- a/promptchain/cli/tui/app.py
+++ b/promptchain/cli/tui/app.py
@@ -32,6 +32,7 @@ from ..utils.file_context_manager import FileContextManager
 from ..utils.output_formatter import OutputFormatter
 from .activity_log_viewer import ActivityLogViewer
 from .approval_screen import ApprovalScreen
+from .model_chooser_screen import ModelChooserScreen
 from .autocomplete_popup import AutocompletePopup
 from .chat_view import ChatView, MessageItem
 from .lingua_client import LinguaCompressor
@@ -226,6 +227,7 @@ class PromptChainApp(App):
         ("ctrl+l", "toggle_log_view", "Activity Logs"),
         ("ctrl+o", "toggle_observe", "Observe"),  # T118: Toggle observe panel
         ("ctrl+t", "toggle_thinking", "Thinking"),  # Toggle thinking/tool detail
+        ("ctrl+n", "choose_model", "Model"),  # Open the model chooser
     ]
 
     # App-level command palette (Ctrl+P). Complements inline '/' parsing in
@@ -654,6 +656,49 @@ class PromptChainApp(App):
             Message(
                 role="system",
                 content=f"[dim]Thinking/tool detail {state} (Ctrl+T to toggle)[/dim]",
+            )
+        )
+
+    def action_choose_model(self) -> None:
+        """Open the interactive model chooser (Ctrl+N or /model).
+
+        On pick, the chosen model is applied to the active agent for this
+        session (in-memory, like /agent use) and the chain is rebuilt. The
+        chooser also seeds ``self._model_catalog`` with its freshly-fetched
+        catalog so ``_model_call_params`` routes the pick (api_base/api_key).
+        """
+        if not self.session:
+            return
+        active = self.session.agents.get(self.session.active_agent or "")
+        current = active.model_name if active else self.session.default_model
+        self.push_screen(ModelChooserScreen(current=current), self._on_model_chosen)
+
+    def _on_model_chosen(self, entry: Optional[Any]) -> None:
+        """Apply a model picked in the chooser to the active agent."""
+        if not entry or not self.session:
+            return  # cancelled
+        from ..models import Message
+
+        agent = self.session.agents.get(self.session.active_agent or "")
+        if agent:
+            agent.model_name = entry.model_name
+        else:
+            self.session.default_model = entry.model_name
+        # Force chain re-creation so the next message uses the new model.
+        self.agent_chain = None
+        try:
+            self.query_one("#status-bar", StatusBar).update_session_info(
+                model_name=entry.model_name
+            )
+        except Exception:
+            pass
+        self.query_one("#chat-view", ChatView).add_message(
+            Message(
+                role="system",
+                content=(
+                    f"[green]Model switched to[/green] [bold]{entry.model_name}[/bold]"
+                    f" [dim]({entry.source})[/dim] for this session."
+                ),
             )
         )
 
@@ -2649,6 +2694,10 @@ class PromptChainApp(App):
                     ),
                 )
                 chat_view.add_message(help_msg)
+
+        elif command.strip() in ("/model", "/models") or command.startswith("/model "):
+            # Open the interactive model chooser (same as Ctrl+N).
+            self.action_choose_model()
 
         elif command.startswith("/agent"):
             # Handle agent commands

--- a/promptchain/cli/tui/model_chooser_screen.py
+++ b/promptchain/cli/tui/model_chooser_screen.py
@@ -1,0 +1,213 @@
+"""Interactive model chooser modal.
+
+A ``ModalScreen`` that lists every selectable model from the live catalog
+(Mac-Studio-local Ollama, Ollama Cloud, curated OpenAI/Gemini), lets the user
+filter-as-they-type, and returns the chosen :class:`ModelEntry`.
+
+Compatible with the app's existing routing (``_model_call_params`` resolves a
+model_name against ``self._model_catalog`` to add ``api_base``/``api_key``): on
+pick the screen hands its **already-fetched full catalog** (incl. local) to
+``self.app._model_catalog`` so the chosen model — local OR cloud — routes
+correctly with no extra network round-trip.
+
+Usage from the app (push + callback, like ApprovalScreen)::
+
+    self.push_screen(ModelChooserScreen(current=agent.model_name), self._on_model_chosen)
+
+The catalog is fetched OFF the event loop (``asyncio.to_thread``) so opening the
+chooser never blocks the TUI while the network sources respond.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import List, Optional
+
+from rich.text import Text
+from textual import on, work
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Input, OptionList, Static
+from textual.widgets.option_list import Option
+
+from ..model_catalog import ModelEntry, build_catalog
+
+# Display order + tag per source.
+_SOURCE_ORDER = {"ollama-local": 0, "ollama-cloud": 1, "openai": 2, "gemini": 3}
+_SOURCE_TAG = {
+    "ollama-local": ("local", "green"),
+    "ollama-cloud": ("cloud", "cyan"),
+    "openai": ("openai", "magenta"),
+    "gemini": ("gemini", "yellow"),
+}
+
+
+class ModelChooserScreen(ModalScreen[Optional[ModelEntry]]):
+    """Filterable picker over the live model catalog. Dismisses with a ModelEntry."""
+
+    DEFAULT_CSS = """
+    ModelChooserScreen {
+        align: center middle;
+        background: $background 70%;
+    }
+    ModelChooserScreen #mc-box {
+        width: 92;
+        max-width: 95%;
+        height: 80%;
+        max-height: 40;
+        padding: 1 2;
+        background: $surface;
+        border: round $accent;
+    }
+    ModelChooserScreen #mc-title {
+        text-style: bold;
+        color: $accent;
+        padding-bottom: 1;
+    }
+    ModelChooserScreen #mc-filter {
+        margin-bottom: 1;
+    }
+    ModelChooserScreen #mc-results {
+        height: 1fr;
+        border: round $panel;
+    }
+    ModelChooserScreen #mc-hint {
+        color: $text-muted;
+        padding-top: 1;
+    }
+    """
+
+    BINDINGS = [
+        ("escape", "cancel", "Cancel"),
+        ("down", "cursor_down", "Down"),
+        ("up", "cursor_up", "Up"),
+    ]
+
+    def __init__(self, current: Optional[str] = None) -> None:
+        super().__init__()
+        self._current = current
+        self._entries: List[ModelEntry] = []
+        self._visible: List[ModelEntry] = []
+        self._loaded = False
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="mc-box"):
+            cur = f"  [dim](current: {self._current})[/dim]" if self._current else ""
+            yield Static(f"Choose a model{cur}", id="mc-title")
+            yield Input(
+                placeholder="type to filter…  (↑↓ move · Enter pick · Esc cancel)",
+                id="mc-filter",
+            )
+            ol: OptionList = OptionList(id="mc-results")
+            ol.add_option(Option(Text("Loading models…", style="dim italic")))
+            yield ol
+            yield Static("", id="mc-hint")
+
+    def on_mount(self) -> None:
+        self.query_one("#mc-filter", Input).focus()
+        self._load_catalog()
+
+    # --- catalog load (off the event loop) ------------------------------- #
+    @work(exclusive=True)
+    async def _load_catalog(self) -> None:
+        try:
+            entries = await asyncio.to_thread(build_catalog)
+        except Exception as exc:  # never let discovery break the modal
+            entries = []
+            self.query_one("#mc-hint", Static).update(f"[red]catalog error: {exc}[/red]")
+        entries.sort(key=lambda e: (_SOURCE_ORDER.get(e.source, 9), e.model_name.lower()))
+        self._entries = entries
+        self._loaded = True
+        self._apply_filter(self.query_one("#mc-filter", Input).value)
+
+    # --- filtering ------------------------------------------------------- #
+    @on(Input.Changed, "#mc-filter")
+    def _on_filter_changed(self, event: Input.Changed) -> None:
+        self._apply_filter(event.value)
+
+    def _apply_filter(self, query: str) -> None:
+        terms = query.lower().split()
+        if terms:
+            self._visible = [
+                e
+                for e in self._entries
+                if all(
+                    t in f"{e.label} {e.model_name} {e.source}".lower() for t in terms
+                )
+            ]
+        else:
+            self._visible = list(self._entries)
+        self._repopulate()
+
+    def _repopulate(self) -> None:
+        ol = self.query_one("#mc-results", OptionList)
+        ol.clear_options()
+        if not self._loaded:
+            ol.add_option(Option(Text("Loading models…", style="dim italic")))
+            return
+        if not self._visible:
+            ol.add_option(
+                Option(
+                    Text(
+                        "No models found — check OLLAMA_HOST / OLLAMA_API_KEY / OPENAI_API_KEY.",
+                        style="dim italic",
+                    )
+                )
+            )
+            self.query_one("#mc-hint", Static).update(
+                f"{len(self._entries)} models in catalog"
+            )
+            return
+        for e in self._visible:
+            ol.add_option(Option(self._format(e)))
+        ol.highlighted = 0
+        self.query_one("#mc-hint", Static).update(
+            f"{len(self._visible)}/{len(self._entries)} models"
+        )
+
+    def _format(self, e: ModelEntry) -> Text:
+        tag, color = _SOURCE_TAG.get(e.source, (e.source, "white"))
+        line = Text()
+        line.append(f"{tag:<6} ", style=color)
+        line.append(e.model_name, style="bold")
+        if e.size_gb:
+            line.append(f"  {e.size_gb}GB", style="dim")
+        if e.reasoning.get("supports"):
+            line.append(f"  think:{e.reasoning.get('extract')}", style="italic dim")
+        if e.model_name == self._current:
+            line.append("  ✓ current", style="green")
+        return line
+
+    # --- selection ------------------------------------------------------- #
+    @on(OptionList.OptionSelected, "#mc-results")
+    def _on_selected(self, event: OptionList.OptionSelected) -> None:
+        self._pick(event.option_index)
+
+    @on(Input.Submitted, "#mc-filter")
+    def _on_submit(self, event: Input.Submitted) -> None:
+        ol = self.query_one("#mc-results", OptionList)
+        idx = ol.highlighted if ol.highlighted is not None else 0
+        self._pick(idx)
+
+    def _pick(self, index: Optional[int]) -> None:
+        if not self._loaded or not self._visible or index is None:
+            return
+        if 0 <= index < len(self._visible):
+            # Hand the freshly-fetched full catalog (incl. local) to the app so
+            # _model_call_params() can route the pick without another probe.
+            try:
+                self.app._model_catalog = self._entries
+            except Exception:
+                pass
+            self.dismiss(self._visible[index])
+
+    # --- navigation while the filter Input holds focus ------------------- #
+    def action_cursor_down(self) -> None:
+        self.query_one("#mc-results", OptionList).action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        self.query_one("#mc-results", OptionList).action_cursor_up()
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)


### PR DESCRIPTION
Merges the model-chooser feature branch. Two commits: an interactive TUI `/model` chooser (Ctrl+N) and a doc for per-step models (own model + params per chain step). Branch had diverged (23 behind main) and was never merged; bringing it current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)