### PR TITLE
docs(spec-015): technique graduation pipeline (bench → gate → production)

### DIFF
--- a/specs/015-technique-graduation-pipeline/plan.md
+++ b/specs/015-technique-graduation-pipeline/plan.md
@@ -1,0 +1,44 @@
+# Plan 015 — Technique Graduation Pipeline
+
+Implements spec.md. Approach: minimal, additive, test-first. No new subsystem — wire the existing
+`promptchain.validity` + local callers into a repurposed bench and a thin graduation surface.
+
+## Architecture
+
+```
+promptchain/utils/agentic_step_processor.py        (PRODUCTION — graduation target)
+  + AgenticStepProcessor(..., verify: VerifyHook | None = None, okf=None, caller=None)   # additive, opt-in, default None
+  + a VerifyHook protocol: (emitted_call, context) -> maybe-replacement-call   (dominance-gated)
+
+promptchain/utils/enhanced_agentic_step_processor.py   (BENCH — experimental)
+  - REMOVE always-on RAG LogicVerifier / Gemini augmentor / adaptive-learning core (audit-rejected)
+  + module-level warning -> docs/ADVERSARIAL_ANALYSIS_SUMMARY.md
+  + experiments: dict[str, cfg] — each an opt-in, default-OFF flagged technique host
+
+promptchain/experiments/                              (NEW — the graduation harness)
+  gate.py     : run_gate(base_fn, treatment_fn, scenarios, reps>=3) -> ValidityReport
+                (wraps promptchain.validity: technique_fired, no_regression, above_noise,
+                 harness_faithful, compare_paired_binary/mcnemar; ValiditySuite.raise_if_failed)
+  bench.py    : pilot a flagged technique on EnhancedAgenticStepProcessor over a held-out slice
+  README.md   : the pilot->validate->graduate runbook
+```
+
+## Key decisions
+
+- **Additive + default-None** on `AgenticStepProcessor` — zero behavior change for existing users (FR-6).
+- **Dominance gate** (FR-4): `verify` may only return a replacement call that passes a check the base
+  call failed; otherwise it returns the base call unchanged. Monotonic by construction — cannot regress.
+- **Local-first** (FR-5): the bench's default verifier is a `RawCaller`/`LlamaCppCaller`/`MLXCaller` through
+  the governor; paid APIs are opt-in only. OKF injects static verification knowledge (no RAG-per-call).
+- **Gate is mandatory before graduation** (FR-3/FR-7): `run_gate` returns a report; graduation PR must
+  attach a passing report + the before/after numbers. A held-out split is required (FR-3) so a technique
+  can't overfit the scenarios it was tuned on.
+- **Negative control** (success criterion 3): a deliberately-null technique must FAIL the gate — proving
+  the gate rejects no-ops, not just rubber-stamps.
+
+## Risks / mitigations
+
+- *Bench rot* (the thing that killed enhanced_ASP): mitigated because the bench now has a defined output
+  (graduations) and a gate; a technique that never graduates is logged + dropped, not left disabled forever.
+- *Gate gaming* (tuning to the eval): mitigated by the held-out split (FR-3) + `above_noise` N≥3 + McNemar.
+- *Cost creep*: local-first default (FR-5); paid callers require an explicit flag.

--- a/specs/015-technique-graduation-pipeline/spec.md
+++ b/specs/015-technique-graduation-pipeline/spec.md
@@ -1,0 +1,84 @@
+# Spec 015 — Technique Graduation Pipeline (experimental bench → validity gate → production param)
+
+Status: Draft · Created 2026-07-05 · Issues #49 (bench), #50 (graduation target)
+
+## 1. Problem
+
+Agentic-tool-call *enhancement* techniques (verify-before-execute, augment, repair, re-plan) keep being
+authored directly into production and claimed to help without proof. The canonical failure is
+`enhanced_agentic_step_processor.py`: a "10x improvement" pitch (RAG `LogicVerifier` + `GeminiReasoningAugmentor`)
+that its **own** 5-agent adversarial audit rejected the *same day* (`docs/ADVERSARIAL_ANALYSIS_SUMMARY.md`:
+DO NOT DEPLOY — +356% tokens, +81% latency, +456% cost, 5 CVSS 7.2–9.1 findings, fail-open approves
+destructive tools). It shipped anyway as a prototype, was never re-measured, is disabled in every test, and
+has zero production callers. The technique wasn't necessarily bad — it **skipped validation**.
+
+The 2026-07 session built the missing rails: `promptchain.validity` (experiment-validity assertions),
+runtime-agnostic local callers (`RawCaller`/`LlamaCppCaller`/`MLXCaller`), OKF knowledge injection, and the
+emit-not-execute / dominance-gate discipline. This spec turns those rails into a **process**.
+
+## 2. Goal
+
+A two-stage lifecycle for agentic techniques so that **nothing reaches production unproven**:
+
+- **`EnhancedAgenticStepProcessor` = the experimental bench.** A technique is piloted here behind an
+  opt-in flag. Messy, experimental, safe to be wrong.
+- **`AgenticStepProcessor` = production.** A technique becomes an **additive, opt-in parameter** here
+  **only after** it passes the validity gate on the bench.
+- **`promptchain.validity` = the turnstile.** The promotion criterion is a passing experiment, not a claim.
+
+```
+[pilot technique] --opt-in flag--> EnhancedAgenticStepProcessor (bench)
+   -> validity experiment: technique_fired + no_regression + above_noise(N>=3, held-out)
+                           + harness_faithful + McNemar (paired pass/fail)
+   -> PROVEN?  no  -> stays on the bench / dropped; logged, NEVER ships
+              yes  -> GRADUATE: add as an additive param on AgenticStepProcessor
+                   -> the bench flag retires / becomes a thin alias
+```
+
+## 3. Functional requirements
+
+- **FR-1 (bench, opt-in).** Every experimental technique on `EnhancedAgenticStepProcessor` is behind an
+  explicit, default-OFF flag (e.g. `experiments={"local_verify": {...}}`). Default construction = base behavior.
+- **FR-2 (repurpose, don't resurrect).** Strip the audit-rejected *always-on* RAG/Gemini core. Keep the shell
+  as the flagged experiment host. A visible module-level warning points at `docs/ADVERSARIAL_ANALYSIS_SUMMARY.md`.
+- **FR-3 (the gate is code, not vibes).** A promotion runs `promptchain.validity` on a held-out scenario set:
+  `technique_fired` (not a no-op), `no_regression` (never worsens a base-correct item), `above_noise`
+  (N≥3 reps, delta beyond base variance), `harness_faithful` (a known model reproduces its known score),
+  and `compare_paired_binary`/`mcnemar` for the paired pass/fail delta. A `ValiditySuite` must pass
+  (`raise_if_failed`) before graduation.
+- **FR-4 (monotonic by construction).** A bench technique may only *replace* the base tool-call when it
+  **provably passes a check the base call failed** (dominance gate); ties go to the base. Emit-not-execute:
+  the harness runs tools, the step only emits — bounding blast radius and call count.
+- **FR-5 (local-first).** Verification/augmentation defaults to a **local caller** (RawCaller/LlamaCpp/MLX)
+  via the governor, not a paid per-call API — directly answering the +456% cost rejection. OKF-injected
+  knowledge (`okf_agentic_context`/`okf_reader_tool`) replaces RAG-per-call where knowledge is static.
+- **FR-6 (graduation = additive param).** A proven technique is added to `AgenticStepProcessor` as an
+  opt-in parameter/hook (no subclass). The salvageable memo/interrupt/context-distiller layer graduates the
+  same way — each still passes the bench + gate first.
+- **FR-7 (provenance).** Each graduation records: the experiment (scenarios, N, seeds), the validity report,
+  and the before/after numbers, linked from the issue. No graduation without a recorded passing experiment.
+
+## 4. Non-goals
+
+- Reviving the always-on RAG-verify + Gemini-augment core as-is (rejected; re-derive only via FR-3).
+- Any "Nx improvement" claim that has not passed the FR-3 gate on a held-out set.
+- Authoring a technique directly on `AgenticStepProcessor` (must transit the bench).
+
+## 5. Success criteria
+
+- The bench hosts ≥1 flagged technique with a runnable validity experiment.
+- A green experiment graduates exactly one technique to an `AgenticStepProcessor` param, with the validity
+  report attached — proving the pipeline end-to-end.
+- A red experiment blocks graduation (demonstrated with a deliberately-null technique — negative control).
+
+## 6. First pilot (the end-to-end proof)
+
+Pilot **"local-caller dominance-gate verify"**: on the bench, an emitted tool-call is re-checked by a local
+caller; the checked call replaces the base call ONLY if it passes a validity check the base failed
+(FR-4). Run the FR-3 experiment on a held-out slice of a tool-calling scenario set (e.g. the existing
+tool-eval-bench scenarios). If it passes → graduate as `AgenticStepProcessor(verify=...)`. If it's within
+noise → it stays on the bench. Either outcome validates the *pipeline*.
+
+## Refs
+Issues #49/#50 · `docs/ADVERSARIAL_ANALYSIS_SUMMARY.md` · `promptchain.validity` (validity_suite/validity_stats)
+· `promptchain/utils/{raw_caller,llama_cpp_caller,mlx_caller,okf_loader}.py` · plan.md · tasks.md

--- a/specs/015-technique-graduation-pipeline/tasks.md
+++ b/specs/015-technique-graduation-pipeline/tasks.md
@@ -1,0 +1,39 @@
+# Tasks 015 — Technique Graduation Pipeline
+
+Ordered, test-first. Each task is independently reviewable. `[P]` = parallelizable.
+
+## Phase 0 — the gate (the turnstile first)
+- T001 `promptchain/experiments/gate.py`: `run_gate(base_fn, treatment_fn, scenarios, reps=3, held_out) -> ValidityReport`.
+  Wraps `promptchain.validity`: technique_fired, no_regression, above_noise(N>=3), harness_faithful,
+  compare_paired_binary/mcnemar. Returns a structured report; `ValiditySuite.raise_if_failed()` on demand.
+- T002 [P] Tests: gate PASSES a genuinely-better treatment; gate FAILS (a) a no-op treatment
+  (negative control), (b) an in-noise treatment, (c) a treatment that regresses a base-correct item.
+- T003 [P] `promptchain/experiments/README.md`: the pilot -> validate -> graduate runbook.
+
+## Phase 1 — repurpose the bench (do no harm)
+- T010 Strip the always-on RAG `LogicVerifier` / `GeminiReasoningAugmentor` / adaptive-learning core from
+  `enhanced_agentic_step_processor.py`; add a module-level warning pointing at
+  `docs/ADVERSARIAL_ANALYSIS_SUMMARY.md`. Preserve the memo/interrupt/context-distiller layer as a
+  graduation candidate cohort (untouched, still tested).
+- T011 Add `experiments: dict[str, cfg]` (default `{}`, all OFF) as the flagged-technique host on the bench.
+- T012 [P] Update/retire the tests that only asserted the removed core; keep the memo/steering tests green.
+
+## Phase 2 — the graduation surface (production, additive)
+- T020 `AgenticStepProcessor`: add opt-in `verify: VerifyHook | None = None` (+ `okf`, `caller`) — default
+  None = zero behavior change. Define the `VerifyHook` protocol (dominance-gated: may only replace on a
+  provable win; else return the base call).
+- T021 [P] Tests: default construction unchanged; a passing verify replaces on a base-fail; verify NEVER
+  regresses a base-correct call (monotonicity assertion, mirrors `no_regression`).
+
+## Phase 3 — the first pilot (prove the pipeline end-to-end)
+- T030 `promptchain/experiments/bench.py`: pilot "local-caller dominance-gate verify" on the bench over a
+  held-out slice of a tool-calling scenario set (local caller via governor; emit-not-execute).
+- T031 Run `run_gate` on the pilot. Attach the ValidityReport + before/after numbers.
+- T032 IF green -> graduate the technique to `AgenticStepProcessor(verify=...)` in a PR that links the
+  report (FR-7). IF in-noise -> record it, leave on the bench. Either way the PIPELINE is validated.
+
+## Definition of done
+- Gate rejects a null technique (negative control passes) and accepts a real one.
+- One technique either graduates (with an attached passing report) or is provably parked — demonstrating
+  both branches of the turnstile.
+- `AgenticStepProcessor` default behavior is byte-unchanged for existing users.


### PR DESCRIPTION
The buildable spec for the dev process agreed in #49/#50: pilot a technique on the EnhancedAgenticStepProcessor **bench**, prove it with **promptchain.validity** (technique_fired + no_regression + above_noise + McNemar on a held-out set), and only then **graduate** it to an additive, opt-in `AgenticStepProcessor` param. Repurposes (not resurrects) the audit-rejected enhanced_ASP. spec.md + plan.md + tasks.md. Refs #49 #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)