### PR TITLE
fix: track the promptchain.experiments package (gitignore ate it)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,7 @@ scripts/runs/*/mlruns/
 # runtime / generated (added 2026-06-25)
 mlflow.db
 /optimized_code_reviewer.json
+
+# Track the promptchain.experiments PACKAGE (the bare "experiments/" rule above is for scratch dirs)
+!promptchain/experiments/
+!promptchain/experiments/**

--- a/promptchain/experiments/README.md
+++ b/promptchain/experiments/README.md
@@ -1,0 +1,56 @@
+# promptchain.experiments — the technique graduation harness
+
+Spec: `specs/015-technique-graduation-pipeline/`. Issues: #49 (bench), #50 (graduation target).
+
+Agentic-technique enhancements earn their way into production. Pilot on the **bench**
+(`EnhancedAgenticStepProcessor`), prove with the **gate** (`promptchain.validity`), and only then
+**graduate** to an additive, opt-in `AgenticStepProcessor` param. Nothing ships unproven — the discipline
+whose absence sank the original enhanced_ASP ("10x" claimed, never measured; see
+`docs/ADVERSARIAL_ANALYSIS_SUMMARY.md`).
+
+```
+[pilot technique] --opt-in flag--> EnhancedAgenticStepProcessor (bench)
+   -> run_gate(...) : technique_fired + no_regression + above_noise(N>=3, held-out) + harness_faithful + McNemar
+   -> PROVEN?  no  -> stays on the bench / dropped; logged, NEVER ships
+              yes  -> GRADUATE: add as an additive AgenticStepProcessor param (attach the report)
+```
+
+## The gate
+
+```python
+from promptchain.experiments import run_gate, split
+
+tune, held_out = split(scenarios, frac=0.5)     # gate on data the technique was NOT tuned on (FR-3)
+
+rep = run_gate(
+    base_fn,          # (scenario) -> output   : the base step
+    treatment_fn,     # (scenario) -> output   : base + the piloted technique
+    held_out,
+    score_fn=lambda s, o: is_correct(s, o),     # (scenario, output) -> bool
+    reps=3,                                      # >= 3 (Henderson/Dodge/Card); the gate enforces this
+    known_fn=None, expected_score=None,          # optional positive control (harness_faithful)
+)
+
+print(rep.summary())
+if rep.passed:            # True only if EVERY validity check passed
+    graduate(...)         # add the technique as an AgenticStepProcessor param; attach rep.summary() to the PR
+else:
+    rep.raise_if_failed() # or keep it on the bench
+```
+
+`run_gate` returns a `GateReport`:
+- `.passed` — True iff `technique_fired` AND `no_regression` AND `above_noise` AND (if a control was given)
+  `harness_faithful` AND a significant paired improvement (McNemar).
+- `.summary()` — the base→treatment scores, verdict, and every check.
+- `.raise_if_failed()` — blocks graduation with an `AssertionError` unless the technique is proven.
+
+## Why each check (what it stops)
+- **technique_fired** — treatment identical to base = the technique never ran (a non-result, not evidence it fails).
+- **no_regression** — never worsens an item the base got right (monotonicity; ties → base).
+- **above_noise** — the delta must exceed run-to-run variance over N≥3 reps; n=1 proves nothing.
+- **harness_faithful** — a known control must reproduce its known score, or the rig is broken.
+- **McNemar** — the correct significance test for paired pass/fail (not a t-test); small effects need real n.
+
+## Graduation checklist (FR-7)
+A graduation PR must attach: the held-out scenarios, `reps`/seeds, `rep.summary()` (the passing report), and
+the before/after numbers. No graduation without a recorded passing experiment.

--- a/promptchain/experiments/__init__.py
+++ b/promptchain/experiments/__init__.py
@@ -1,0 +1,9 @@
+"""promptchain.experiments — the technique graduation harness (spec-015).
+
+The GATE (`run_gate`) is the turnstile: a technique piloted on the experimental bench
+(EnhancedAgenticStepProcessor) may graduate to a production `AgenticStepProcessor` param ONLY by passing
+this gate on a held-out set. See `promptchain/experiments/README.md` and specs/015-technique-graduation-pipeline/.
+"""
+from .gate import run_gate, GateReport, split
+
+__all__ = ["run_gate", "GateReport", "split"]

--- a/promptchain/experiments/gate.py
+++ b/promptchain/experiments/gate.py
@@ -1,0 +1,119 @@
+"""The graduation GATE — the turnstile of spec-015's technique pipeline.
+
+A technique earns promotion from the experimental bench (EnhancedAgenticStepProcessor) to a production
+`AgenticStepProcessor` param ONLY by passing this gate on a HELD-OUT scenario set. The gate is code, not a
+claim: it runs the base vs. the treatment over N reps and applies `promptchain.validity` —
+`technique_fired` (not a no-op), `no_regression` (never worsens a base-correct item), `above_noise` (delta
+beyond run-to-run variance, N>=3), optional `harness_faithful` (a known control reproduces its known
+score), and `compare_paired_binary`/`mcnemar` for the paired pass/fail delta. A `GateReport.passed` is True
+only if ALL of them pass.
+
+This is the machinery that makes "does technique X actually help?" answerable — the exact discipline whose
+absence sank the original enhanced_agentic_step_processor ("10x" claimed, never measured; see spec-015).
+
+Usage:
+    rep = run_gate(base_fn, treatment_fn, held_out_scenarios, score_fn=is_correct, reps=3)
+    rep.raise_if_failed()          # block graduation unless proven
+    if rep.passed: graduate(...)   # attach rep.summary() to the PR (FR-7)
+"""
+from promptchain.validity import (
+    Check, ValiditySuite,
+    technique_fired, no_regression, above_noise, harness_faithful,
+    compare_paired_binary,
+)
+
+
+def split(scenarios, frac=0.5, seed=0):
+    """Deterministic tune/test split so a technique can't be gated on the data it was tuned on (FR-3).
+    Returns (tune, held_out). Interleaved by a fixed stride — no RNG (keeps runs reproducible)."""
+    ordered = list(scenarios)
+    step = max(1, round(1 / max(1e-9, 1 - frac))) if frac < 1 else 1
+    held = [s for i, s in enumerate(ordered) if (i + 1 + seed) % 2 == 0][: max(1, int(len(ordered) * (1 - frac)) or 1)]
+    heldset = set(map(id, held))
+    tune = [s for s in ordered if id(s) not in heldset]
+    return tune, held
+
+
+class GateReport:
+    """The result of a graduation gate. `passed` is True only if every validity check passed."""
+
+    def __init__(self, suite, paired, base_scores, treatment_scores):
+        self.suite = suite
+        self.paired = paired
+        self.base_scores = base_scores
+        self.treatment_scores = treatment_scores
+
+    @property
+    def passed(self):
+        return self.suite.ok
+
+    def summary(self):
+        bm = sum(self.base_scores) / len(self.base_scores)
+        tm = sum(self.treatment_scores) / len(self.treatment_scores)
+        head = (f"GATE {'PASS' if self.passed else 'FAIL'} — base {bm:.1f} -> treatment {tm:.1f} "
+                f"(verdict: {self.paired['verdict']})")
+        return head + "\n" + self.suite.report()
+
+    def raise_if_failed(self):
+        """Block graduation: raises AssertionError unless every check passed."""
+        self.suite.raise_if_failed()
+        return self
+
+
+def run_gate(base_fn, treatment_fn, scenarios, *, score_fn, reps=3,
+             known_fn=None, expected_score=None, alpha=0.05, name="gate",
+             max_identical=0.95, max_regression=0.02):
+    """Run the graduation gate.
+
+    base_fn / treatment_fn : (scenario) -> output. Called `reps` times per scenario (stochastic in prod).
+    score_fn               : (scenario, output) -> bool  (did this output pass?).
+    scenarios              : the HELD-OUT set to gate on (use `split` first).
+    reps                   : >= 3 for `above_noise` (per Henderson/Dodge/Card).
+    known_fn/expected_score: optional positive control for `harness_faithful`.
+
+    Returns a GateReport. `passed` iff technique_fired AND no_regression AND above_noise AND
+    (harness_faithful if a control was given) AND a significant paired improvement (McNemar).
+    """
+    n = len(scenarios)
+    base_scores, treat_scores = [], []
+    base_out0, treat_out0 = [], []                       # rep-0 outputs, for no-op detection
+    per_base = [[] for _ in range(n)]                    # per-scenario correctness across reps
+    per_treat = [[] for _ in range(n)]
+
+    for r in range(reps):
+        bc = tc = 0
+        for i, sc in enumerate(scenarios):
+            bo = base_fn(sc)
+            to = treatment_fn(sc)
+            bok = bool(score_fn(sc, bo))
+            tok = bool(score_fn(sc, to))
+            if r == 0:
+                base_out0.append(bo)
+                treat_out0.append(to)
+            per_base[i].append(bok)
+            per_treat[i].append(tok)
+            bc += bok
+            tc += tok
+        base_scores.append(100.0 * bc / n)
+        treat_scores.append(100.0 * tc / n)
+
+    # majority-vote correctness per scenario (stable across stochastic reps)
+    base_correct = [sum(x) > len(x) / 2 for x in per_base]
+    treat_correct = [sum(x) > len(x) / 2 for x in per_treat]
+
+    suite = ValiditySuite(name)
+    suite.add(technique_fired(base_out0, treat_out0, max_identical))
+    suite.add(no_regression(base_correct, treat_correct, max_regression))
+    suite.add(above_noise(base_scores, treat_scores, min_reps=3))  # hard floor: n>=3 (spec FR-3)
+    if known_fn is not None and expected_score is not None:
+        known = 100.0 * sum(bool(score_fn(sc, known_fn(sc))) for sc in scenarios) / n
+        suite.add(harness_faithful(known, expected_score))
+
+    paired = compare_paired_binary(base_correct, treat_correct, alpha)
+    suite.add(Check(
+        "mcnemar_improvement",
+        bool(paired["significant"]) and paired["treatment_rate"] > paired["base_rate"],
+        f"paired pass/fail: {paired['verdict']} (McNemar p={paired['mcnemar']['p']:.3f})",
+        paired,
+    ))
+    return GateReport(suite, paired, base_scores, treat_scores)


### PR DESCRIPTION
Hotfix: PR #56 landed the gate test but the `experiments/` gitignore rule (for scratch dirs) silently excluded the `promptchain/experiments/` package — main's test imports a missing module. Adds a gitignore negation + the 3 package files. Restores green main.