### PR TITLE
fix(cli/tui): persist TUI session history every turn + on teardown

### DIFF
--- a/promptchain/cli/tui/app.py
+++ b/promptchain/cli/tui/app.py
@@ -4780,6 +4780,12 @@ IMPORTANT: For conversational queries, ALWAYS prefix refined_query with "Respond
         # Update status bar
         status_bar.update_session_info(message_count=len(self.session.messages))
 
+        # Persist the turn now. check_autosave() flushes to SQLite + messages.jsonl
+        # once the message/time threshold is met, so history survives a non-clean
+        # exit (Ctrl+C, terminal close, os._exit backstop) instead of only being
+        # saved on /exit. Without this the built-in auto-save never fires.
+        self.session.check_autosave(self.session_manager)
+
     async def _handle_workflow_message(self, content: str, workflow: "WorkflowState"):
         """Handle message when workflow is active (T091).
 
@@ -5004,6 +5010,10 @@ IMPORTANT: For conversational queries, ALWAYS prefix refined_query with "Respond
         # Update status bar message count
         status_bar.update_session_info(message_count=len(self.session.messages))
 
+        # Persist the workflow turn now (see handle_user_message) so history
+        # survives a non-clean exit rather than only saving on /exit.
+        self.session.check_autosave(self.session_manager)
+
     async def _display_system_message(self, message: str) -> None:
         """Display system message in chat with styling (T042).
 
@@ -5083,6 +5093,22 @@ IMPORTANT: For conversational queries, ALWAYS prefix refined_query with "Respond
         """Quit (Ctrl+D / quit binding): arm the failsafe, then exit cleanly."""
         self._arm_hard_exit()
         self.exit()
+
+    async def on_unmount(self) -> None:
+        """Textual teardown hook — the ACTUAL lifecycle event Textual fires.
+
+        ``on_exit`` (below) holds the intended shutdown save + MLflow flush, but
+        ``on_exit`` is not a Textual event name (App has no such hook in Textual
+        8.x), so Textual never invoked it and the transcript was only persisted
+        when the user literally typed ``/exit``. Ctrl+D/action_quit and Ctrl+C
+        quit without saving. Delegating here wires that cleanup to every exit
+        path before the ``_arm_hard_exit`` os._exit backstop can fire.
+        """
+        try:
+            await self.on_exit()
+        except Exception:
+            # Never let a teardown error hang the exit.
+            pass
 
     async def on_exit(self):
         """Handle app exit - save session and cleanup observers."""

--- a/tests/cli/unit/test_history_persistence_gap.py
+++ b/tests/cli/unit/test_history_persistence_gap.py
@@ -1,0 +1,138 @@
+"""Regression tests for the TUI history-collection gap.
+
+Bug (observed 2026-07-06): TUI sessions lost most of their conversation
+transcript. In one real session the router had handled 38 distinct user
+queries but only 6 turns survived in ``messages.jsonl`` (84% loss).
+
+Root cause: the TUI turn loop never triggered persistence. The built-in
+``Session.check_autosave`` (save every N messages / T seconds) and the
+app's ``on_exit`` cleanup were both effectively dead code — ``on_exit`` is
+not a Textual lifecycle event so Textual never called it, and no turn handler
+called ``check_autosave``. The transcript was flushed to disk only when the
+user literally typed ``/exit``; Ctrl+C / Ctrl+D / terminal-close lost every
+turn since the last (rare) save.
+
+Fix: ``handle_user_message`` / ``_handle_workflow_message`` now call
+``self.session.check_autosave(self.session_manager)`` after each turn, and a
+real ``on_unmount`` hook delegates to ``on_exit`` so every exit path flushes.
+
+These tests pin the persistence-layer behaviour (turns survive without a
+clean ``/exit``) and guard that the TUI turn handlers keep the wiring.
+"""
+
+import inspect
+import json
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+class TestHistoryPersistenceGap:
+    @pytest.fixture
+    def temp_sessions_dir(self):
+        temp_dir = Path(tempfile.mkdtemp())
+        yield temp_dir
+        shutil.rmtree(temp_dir)
+
+    @pytest.fixture
+    def session_manager(self, temp_sessions_dir):
+        from promptchain.cli.session_manager import SessionManager
+
+        return SessionManager(sessions_dir=temp_sessions_dir)
+
+    def _read_persisted_messages(self, session_manager, session_id):
+        path = session_manager.sessions_dir / session_id / "messages.jsonl"
+        if not path.exists():
+            return []
+        return [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+
+    def _run_turns(self, session, session_manager, n_turns):
+        """Drive the TUI turn loop: per turn add user+assistant, then autosave."""
+        for i in range(n_turns):
+            session.add_message(role="user", content=f"user query {i}")
+            session.add_message(
+                role="assistant",
+                content=f"assistant reply {i}",
+                metadata={"model_name": "openai/gpt-4.1-mini"},
+            )
+            # The line the TUI turn handlers were missing (the fix).
+            session.check_autosave(session_manager)
+
+    def test_periodic_autosave_persists_bulk_without_clean_exit(self, session_manager):
+        """Reproduces the 84%-loss scenario: many turns, NO /exit.
+
+        Before the fix nothing called ``check_autosave`` so ``messages.jsonl``
+        stayed empty/stale until a rare ``/exit``. With per-turn autosave the
+        bulk of the transcript is on disk mid-session — here every turn past the
+        first autosave interval is already durable.
+        """
+        session = session_manager.create_session("gap-repro", Path.cwd())
+        n_turns = 8
+        self._run_turns(session, session_manager, n_turns)
+
+        persisted = self._read_persisted_messages(session_manager, session.id)
+        user_turns = [m for m in persisted if m["role"] == "user"]
+
+        # Interval autosave (every 5 msgs) leaves only a small tail unflushed;
+        # the bulk is durable mid-session (was 0 before the fix).
+        assert len(user_turns) >= n_turns - 2, (
+            f"expected the bulk of {n_turns} turns persisted mid-session, got "
+            f"{len(user_turns)} (persistence gap regressed)"
+        )
+
+    def test_full_history_persists_after_shutdown_flush(self, session_manager):
+        """End-to-end: per-turn autosave + shutdown flush == complete history.
+
+        Models the whole fix — the turn loop calls ``check_autosave``, and
+        teardown (app ``on_unmount`` → ``on_exit``, mirrored here by the
+        model's ``Session.on_exit``) does the final flush. Result: zero loss,
+        even for the tail turns the interval autosave hadn't reached yet.
+        """
+        session = session_manager.create_session("gap-repro-full", Path.cwd())
+        n_turns = 8
+        self._run_turns(session, session_manager, n_turns)
+
+        # Final flush on shutdown (what on_unmount now guarantees).
+        session.on_exit(session_manager)
+
+        persisted = self._read_persisted_messages(session_manager, session.id)
+        user_turns = [m for m in persisted if m["role"] == "user"]
+
+        assert len(user_turns) == n_turns, (
+            f"expected all {n_turns} user turns persisted after shutdown flush, "
+            f"got {len(user_turns)} (persistence gap regressed)"
+        )
+        assert [m["content"] for m in user_turns] == [
+            f"user query {i}" for i in range(n_turns)
+        ]
+
+    def test_tui_turn_handlers_invoke_check_autosave(self):
+        """Guard the wiring: both TUI turn handlers must trigger persistence.
+
+        A source-level check so that if someone removes the ``check_autosave``
+        call from a turn handler, this test fails instead of silently
+        re-introducing the history gap. (Full async-app execution is covered by
+        the integration suite; this stays fast and harness-independent.)
+        """
+        from promptchain.cli.tui.app import PromptChainApp
+
+        for method_name in ("handle_user_message", "_handle_workflow_message"):
+            src = inspect.getsource(getattr(PromptChainApp, method_name))
+            assert "check_autosave" in src, (
+                f"{method_name} no longer calls check_autosave — the TUI history "
+                f"persistence gap has regressed"
+            )
+
+    def test_on_unmount_is_wired_to_shutdown_save(self):
+        """``on_unmount`` (the real Textual hook) must exist and reach on_exit.
+
+        ``on_exit`` alone is dead code (not a Textual event); on_unmount is what
+        Textual actually fires on teardown, so it must drive the shutdown save.
+        """
+        from promptchain.cli.tui.app import PromptChainApp
+
+        assert hasattr(PromptChainApp, "on_unmount"), "on_unmount hook missing"
+        src = inspect.getsource(PromptChainApp.on_unmount)
+        assert "on_exit" in src, "on_unmount does not delegate to on_exit"


### PR DESCRIPTION
## Problem

TUI sessions were silently losing most of their conversation transcript. In a sampled `default` session, the router had handled **38 distinct user queries but only 6 survived in `messages.jsonl` (84% loss)**.

## Root cause — three dead persistence paths

1. `Session.check_autosave()` (save every N msgs / T sec) was built and tested but **never called by any TUI turn handler**.
2. `app.on_exit()` (the shutdown save + MLflow flush) is **not a Textual lifecycle event name** (Textual 8.x `App` has no `on_exit` hook), so Textual never invoked it. A comment in `main.py` even claimed "the session is already saved in App.on_exit" — false.
3. Net effect: the transcript flushed to disk **only when the user typed `/exit`**. Ctrl+C, Ctrl+D/`action_quit`, terminal close, and the `os._exit()` hard-exit backstop all quit **without saving**.

(The router observability log `history.jsonl` was fine — it flushes per call. Only the conversation transcript was broken. The empty `message_log` SQLite table is *not* this bug — it's the agent-to-agent bus, correctly empty.)

## Fix (`promptchain/cli/tui/app.py`, +26 lines)

- `handle_user_message` and `_handle_workflow_message` now call `self.session.check_autosave(self.session_manager)` after each turn.
- Added a real `on_unmount` Textual hook that delegates to the existing `on_exit`, so **every** exit path (Ctrl+C/D, quit, close) flushes the tail before the hard-exit backstop fires — without touching `on_exit` or its existing test.

**Effect: 84% loss → ~0% on any graceful exit** (≤2-turn residual only on an ungraceful SIGKILL/OOM/power-loss).

## Tests

New `tests/cli/unit/test_history_persistence_gap.py` (4 tests, all green):
- reproduces the multi-turn-without-`/exit` scenario,
- proves full history after a shutdown flush,
- guards that both turn handlers keep the `check_autosave` wiring,
- guards that `on_unmount` delegates to `on_exit`.

**Zero regressions**: the repo's pre-existing test failures (a stale `Agent` constructor + missing `pytest-asyncio` config) are byte-identical before and after this change.

## Follow-ups (flagged, not in scope)

- `messages.jsonl` is written in `"w"` full-overwrite mode despite an "append-only" comment → O(n²) on long sessions; per-turn append would give true zero-loss.
- Slash-command results append via `session.messages.append(...)` directly, bypassing `add_message`, so they don't count toward the autosave threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)