### PR TITLE
perf(cli): append-only messages.jsonl writes + count slash-command turns

### DIFF
--- a/promptchain/cli/session_manager.py
+++ b/promptchain/cli/session_manager.py
@@ -482,6 +482,9 @@ class SessionManager:
         # Create messages file (empty JSONL)
         messages_file = session_dir / "messages.jsonl"
         messages_file.touch()
+        # Nothing persisted yet — the first save appends all messages (see
+        # save_session's append-only logic).
+        session._persisted_count = 0
 
         # Insert session into database
         conn = sqlite3.connect(self.db_path)
@@ -676,6 +679,9 @@ class SessionManager:
                     for line in f:
                         if line.strip():
                             session.messages.append(Message.from_jsonl(line))
+            # Everything just loaded is already on disk — so append-only saves
+            # (see save_session) only write messages added after this point.
+            session._persisted_count = len(session.messages)
 
             # ✅ Phase 3: Initialize ActivityLogger for loaded session
             # Reconnects to existing activity log database
@@ -854,12 +860,25 @@ class SessionManager:
         finally:
             conn.close()
 
-        # Save messages to JSONL (append-only)
+        # Save messages to JSONL — append-only. Conversation history only ever
+        # grows (messages are appended, never edited in place), so we append the
+        # tail written since the last save instead of rewriting the whole file
+        # each time. That turns per-turn saving from O(n) into O(new) and avoids
+        # the O(n^2) cost of rewriting a long transcript on every turn.
+        # Full rewrite is used only as a fallback: the file is missing, or the
+        # in-memory list is SHORTER than what we already persisted (a clear /
+        # compaction shrank it) — in which case the on-disk copy is stale.
         messages_file = self.sessions_dir / session.id / "messages.jsonl"
+        persisted = getattr(session, "_persisted_count", 0)
+        total = len(session.messages)
+        full_rewrite = persisted > total or not messages_file.exists()
         try:
-            with open(messages_file, "w") as f:
-                for message in session.messages:
+            mode = "w" if full_rewrite else "a"
+            start = 0 if full_rewrite else persisted
+            with open(messages_file, mode) as f:
+                for message in session.messages[start:]:
                     f.write(message.to_jsonl() + "\n")
+            session._persisted_count = total
         except Exception as e:
             # Log file writing error
             try:

--- a/promptchain/cli/tui/app.py
+++ b/promptchain/cli/tui/app.py
@@ -3053,9 +3053,7 @@ class PromptChainApp(App):
                 chat_view.add_message(result_msg)
 
                 # Add to session history
-                if self.session:
-                    self.session.messages.append(Message(role="user", content=command))
-                    self.session.messages.append(result_msg)
+                self._record_command_turn(command, result_msg)
             else:
                 error_msg = Message(
                     role="system",
@@ -3130,9 +3128,7 @@ class PromptChainApp(App):
                 chat_view.add_message(result_msg)
 
                 # Add to session history
-                if self.session:
-                    self.session.messages.append(Message(role="user", content=command))
-                    self.session.messages.append(result_msg)
+                self._record_command_turn(command, result_msg)
             else:
                 error_msg = Message(
                     role="system",
@@ -3215,9 +3211,7 @@ class PromptChainApp(App):
                 chat_view.add_message(result_msg)
 
                 # Add to session history
-                if self.session:
-                    self.session.messages.append(Message(role="user", content=command))
-                    self.session.messages.append(result_msg)
+                self._record_command_turn(command, result_msg)
             else:
                 error_msg = Message(
                     role="system",
@@ -3300,9 +3294,7 @@ class PromptChainApp(App):
                 chat_view.add_message(result_msg)
 
                 # Add to session history
-                if self.session:
-                    self.session.messages.append(Message(role="user", content=command))
-                    self.session.messages.append(result_msg)
+                self._record_command_turn(command, result_msg)
             else:
                 error_msg = Message(
                     role="system",
@@ -3402,9 +3394,7 @@ class PromptChainApp(App):
                 chat_view.add_message(result_msg)
 
                 # Add to session history
-                if self.session:
-                    self.session.messages.append(Message(role="user", content=command))
-                    self.session.messages.append(result_msg)
+                self._record_command_turn(command, result_msg)
             else:
                 error_msg = Message(
                     role="system",
@@ -3487,9 +3477,7 @@ class PromptChainApp(App):
                 chat_view.add_message(result_msg)
 
                 # Add to session history
-                if self.session:
-                    self.session.messages.append(Message(role="user", content=command))
-                    self.session.messages.append(result_msg)
+                self._record_command_turn(command, result_msg)
             else:
                 error_msg = Message(
                     role="system",
@@ -4266,6 +4254,25 @@ IMPORTANT: For conversational queries, ALWAYS prefix refined_query with "Respond
             status_bar.update_session_info(
                 active_agent=agent_name, model_name=active_agent.model_name
             )
+
+    def _record_command_turn(self, command: str, result_msg: "Message") -> None:
+        """Persist a slash-command turn (user command + its result) to history.
+
+        These bypass ``session.add_message`` because ``result_msg`` is a prebuilt
+        Message object also handed to the chat view, so appending directly keeps
+        one object across UI + history. But that also skips add_message's
+        autosave bookkeeping — so bump the counter for the two messages and run
+        check_autosave here, otherwise command turns wouldn't count toward the
+        auto-save threshold and could be lost on a non-clean exit.
+        """
+        if not self.session:
+            return
+        self.session.messages.append(Message(role="user", content=command))
+        self.session.messages.append(result_msg)
+        self.session.messages_since_save = (
+            getattr(self.session, "messages_since_save", 0) + 2
+        )
+        self.session.check_autosave(self.session_manager)
 
     async def handle_user_message(self, content: str):
         """Handle user message (non-command) with AgentChain integration (T032-T034).

--- a/tests/cli/unit/test_append_only_persistence.py
+++ b/tests/cli/unit/test_append_only_persistence.py
@@ -1,0 +1,134 @@
+"""Tests for append-only messages.jsonl persistence + slash-command turn recording.
+
+Follow-ups to the TUI history-persistence fix:
+
+1. save_session now APPENDS only the messages added since the last save
+   (tracked via session._persisted_count) instead of rewriting the whole
+   transcript each turn — O(new) instead of O(n) per save, killing the O(n^2)
+   cost on long sessions. Full rewrite is a fallback only when the file is
+   missing or the in-memory list shrank (clear/compaction).
+
+2. Slash-command turns previously appended to session.messages directly,
+   bypassing add_message's autosave bookkeeping. app._record_command_turn now
+   bumps the counter and runs check_autosave so those turns are counted + saved.
+"""
+
+from __future__ import annotations
+
+import inspect
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+class TestAppendOnlyPersistence:
+    @pytest.fixture
+    def temp_sessions_dir(self):
+        d = Path(tempfile.mkdtemp())
+        yield d
+        shutil.rmtree(d)
+
+    @pytest.fixture
+    def session_manager(self, temp_sessions_dir):
+        from promptchain.cli.session_manager import SessionManager
+
+        return SessionManager(sessions_dir=temp_sessions_dir)
+
+    def _lines(self, session_manager, session_id):
+        p = session_manager.sessions_dir / session_id / "messages.jsonl"
+        return [l for l in p.read_text().splitlines() if l.strip()]
+
+    def test_no_duplication_across_saves(self, session_manager):
+        """Two saves with new messages between them → each message once."""
+        s = session_manager.create_session("append1", Path.cwd())
+        s.add_message(role="user", content="one")
+        s.add_message(role="assistant", content="two")
+        session_manager.save_session(s)
+        s.add_message(role="user", content="three")
+        s.add_message(role="assistant", content="four")
+        session_manager.save_session(s)
+
+        lines = self._lines(session_manager, s.id)
+        assert len(lines) == 4
+        contents = [l for l in lines]
+        # each unique content appears exactly once
+        for token in ("one", "two", "three", "four"):
+            assert sum(token in c for c in contents) == 1
+
+    def test_second_save_appends_not_rewrites(self, session_manager):
+        """The bytes written by the first save are preserved verbatim as a prefix."""
+        s = session_manager.create_session("append2", Path.cwd())
+        s.add_message(role="user", content="first")
+        session_manager.save_session(s)
+        path = session_manager.sessions_dir / s.id / "messages.jsonl"
+        after_first = path.read_text()
+
+        s.add_message(role="assistant", content="second")
+        session_manager.save_session(s)
+        after_second = path.read_text()
+
+        assert after_second.startswith(after_first)  # true append, no rewrite
+        assert "second" in after_second[len(after_first):]
+
+    def test_noop_save_writes_nothing(self, session_manager):
+        """Saving with no new messages must not append anything."""
+        s = session_manager.create_session("append3", Path.cwd())
+        s.add_message(role="user", content="only")
+        session_manager.save_session(s)
+        path = session_manager.sessions_dir / s.id / "messages.jsonl"
+        size1 = path.stat().st_size
+        session_manager.save_session(s)  # no new messages
+        assert path.stat().st_size == size1
+        assert len(self._lines(session_manager, s.id)) == 1
+
+    def test_reload_then_save_no_duplication(self, session_manager):
+        """Loading a session sets _persisted_count so later saves don't re-append."""
+        s = session_manager.create_session("append4", Path.cwd())
+        s.add_message(role="user", content="alpha")
+        s.add_message(role="assistant", content="beta")
+        session_manager.save_session(s)
+
+        reloaded = session_manager.load_session("append4")
+        assert getattr(reloaded, "_persisted_count", None) == 2
+        reloaded.add_message(role="user", content="gamma")
+        session_manager.save_session(reloaded)
+
+        lines = self._lines(session_manager, s.id)
+        assert len(lines) == 3  # alpha, beta, gamma — no duplicates
+        assert sum("alpha" in l for l in lines) == 1
+
+    def test_full_rewrite_fallback_on_shrink(self, session_manager):
+        """If the in-memory list is shorter than persisted, do a full rewrite."""
+        s = session_manager.create_session("append5", Path.cwd())
+        for i in range(4):
+            s.add_message(role="user", content=f"m{i}")
+        session_manager.save_session(s)
+        assert len(self._lines(session_manager, s.id)) == 4
+
+        # Simulate a clear/compaction: list shrinks below persisted count.
+        s.messages = s.messages[:1]
+        session_manager.save_session(s)
+
+        lines = self._lines(session_manager, s.id)
+        assert len(lines) == 1  # file reflects the shrunk list, not stale 4
+        assert "m0" in lines[0]
+
+
+class TestCommandTurnRecording:
+    def test_no_direct_append_sites_remain(self):
+        """All slash-command turns must route through _record_command_turn."""
+        from promptchain.cli.tui.app import PromptChainApp
+
+        src = inspect.getsource(PromptChainApp)
+        # The only remaining direct appends are the two inside the helper itself.
+        assert src.count("self.session.messages.append") == 2
+
+    def test_helper_counts_and_saves(self):
+        """_record_command_turn must bump the counter AND trigger check_autosave."""
+        from promptchain.cli.tui.app import PromptChainApp
+
+        src = inspect.getsource(PromptChainApp._record_command_turn)
+        assert "messages_since_save" in src
+        assert "check_autosave" in src


### PR DESCRIPTION
Two follow-ups to the TUI history-persistence fix (#58).

## 1. Append-only transcript writes
`save_session` rewrote the **entire** `messages.jsonl` on every save (`"w"` mode) despite an "append-only" comment — O(n) per save, **O(n²) over a long session**. Conversation history only ever grows (messages are appended, never edited in place), so we now track `_persisted_count` on the session and **append only the tail** added since the last save.

- Full rewrite kept as a fallback for the file-missing or list-shrank (clear/compaction) cases.
- `_persisted_count` seeded to 0 in `create_session` and to `len(messages)` in `load_session`, so a reload doesn't re-append already-persisted turns.

## 2. Slash-command turns now count toward autosave
Six command handlers appended the command + result `Message` directly to `session.messages`, bypassing `add_message`'s autosave bookkeeping — so those turns weren't counted and could be lost on a non-clean exit. Extracted **`_record_command_turn()`** (appends, bumps `messages_since_save`, runs `check_autosave`), replacing all six duplicated blocks.

## Tests
`tests/cli/unit/test_append_only_persistence.py` (7 tests): no duplication across saves, true append (prefix preserved verbatim), no-op save writes nothing, reload-then-save no duplication, full-rewrite fallback on shrink, and guards that the command handlers route through `_record_command_turn`. All green, together with the #58 gap tests (11 total).

**No regressions**: the persistence suite's failing tests all share the pre-existing `Agent` model-name-format `ValueError` (`agent_config.py:188`, stale tests passing bare model names) — untouched by this change, which only edits `session_manager.py` + `app.py`.

Built in an isolated worktree off `origin/main` to avoid colliding with concurrent PromptChain work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)