### PR TITLE
feat(agent_comms): agent-communication patterns package (v0.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-11
+
 ### Added
+- **`agent_comms`** (`promptchain.patterns.agent_comms`) — a new package: every
+  agent-to-agent communication pattern (dyad, sequential pipeline, moderated group,
+  broadcast, handoff routing, FSM, nesting) as **static control flow with agentic
+  participants**. Each agent is a true `AgenticStepProcessor` (its own reason+tool loop,
+  `tools=[...]`); the mesh — selector / router / termination — is pure Callables, so a
+  model never drives orchestration. Includes a tunable **orchestrator**: the static
+  `group()` + `by_capability()` (route by declared agent capabilities), or an agentic
+  manager agent via `orchestrator()` with `select` / `steer` / `full` authority and
+  capability-aware **open-question forwarding** (a question left "in the air" is routed to
+  whoever can answer it); plus `captain()` (a sub-team presented as one agent), `dyad` /
+  `pipeline` / `group` / `broadcast` / `as_agent`, the G4 selector menu, and `EchoAgent`
+  for offline control-flow tests. See `promptchain/patterns/agent_comms/README.md`,
+  `tests/test_agent_comms.py` (16 offline, no LLM), `examples/agent_comms_demo.py`.
 - **`ExternalLoop`** (`promptchain.utils.external_loop`) — a deterministic external
   loop, the external analog of `AgenticStepProcessor`'s internal loop. Always loops
   with a **required, default-on guard** (`max_iters` always-on + optional `max_seconds`

--- a/examples/agent_comms_demo.py
+++ b/examples/agent_comms_demo.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Live demo of promptchain.patterns.agent_comms with real PromptChain workers.
+
+Run: OPENAI_API_KEY=... python3 examples/agent_comms_demo.py
+Every "agent" is one line; every pattern is a few lines. A Callable decides flow.
+"""
+from promptchain.patterns.agent_comms import (
+    Msg, agent, broadcast, dyad, fsm, group, keyword_rule, llm_auto, pipeline,
+    quorum, round_robin, router, sel_from_router,
+)
+
+def lookup_metric(metric: str) -> str:
+    """Return the current value of a named business metric (churn, mrr)."""
+    return {"churn": "7.3%", "mrr": "$42k"}.get(metric.strip().lower(), "unknown")
+
+
+A = agent("A", "a cautious risk-focused engineer")
+B = agent("B", "an optimistic ship-it product lead")
+C = agent("C", "an evidence-driven researcher", tools=[lookup_metric])  # a TRUE agent w/ a tool
+
+
+def show(title, transcript):
+    print(f"\n━━━ {title} ━━━")
+    for m in transcript:
+        print("  ", m)
+
+
+# G3+G4 — moderated group, round-robin, stop when all 3 weigh in
+show("G3 group · round_robin · quorum(3)",
+     group([A, B, C], round_robin(), term=[quorum(3)], max_turns=12).run("Ship Friday? Decide."))
+
+# G4 — llm_auto: a judge names who speaks next
+judge = agent("M", "a neutral facilitator")
+show("G4 group · llm_auto",
+     group([A, B, C], llm_auto(judge), term=[quorum(3)], max_turns=6).run("Ship Friday? Decide."))
+
+# G5 — FSM: A->B->C->A only
+show("G5 group · fsm(A->B->C->A)",
+     group([A, B, C], fsm({"A": ["B"], "B": ["C"], "C": ["A"]}, round_robin()), max_turns=4).run("Ship Friday?"))
+
+# G1 — dyad
+show("G1 dyad(A,B)", dyad(A, B, "Ship Friday, yes or no?", max_turns=3))
+
+# G7 — router picks ONE agent for a query, that agent answers
+route = router([keyword_rule(["data", "evidence"], C), keyword_rule(["risk", "bug"], A)], fallback=B)
+picked = route("What does the data say about churn?")
+t = [Msg("Facilitator", "What does the data say about churn?")]
+picked.say(t)
+show("G7 router · 'data' -> C", t)
+
+# G2 — pipeline (carryover)
+print("\n━━━ G2 pipeline(A->B->C) ━━━")
+print("  ", pipeline([A, B, C]).run("Idea: an app that reminds you to drink water."))
+
+# G6 — broadcast + synthesizer
+synth = agent("S", "a synthesizer who merges views into one verdict")
+replies, verdict = broadcast([A, B, C], synth).run("In one line, is Friday realistic?")
+show("G6 broadcast + synth", replies + [Msg("S", verdict)])
+
+print("\ndone.")

--- a/promptchain/patterns/agent_comms/README.md
+++ b/promptchain/patterns/agent_comms/README.md
@@ -1,0 +1,153 @@
+# `promptchain.patterns.agent_comms`
+
+Every way agents talk to each other — dyad, pipeline, group, broadcast, routing,
+FSM, nesting. **Agentic participants, static orchestration:** each *agent* is a real
+**`AgenticStepProcessor`** (its own internal reason-act loop, can call tools), while a
+plain **Callable** — never a model — decides who-speaks-next and when-to-stop. That is
+the correct split: agentic where it belongs (the agents), static where it belongs (the
+control flow). Note `feedback-static-not-agentic-promptchain`: "static" is scoped to one
+experiment — *PromptChain does BOTH static and agentic, both first-class.*
+
+> This is the "graduated" home of the patterns prototyped in `twicedata_intra`'s
+> `secretary_mesh`. There, the workers were raw `urllib` callers; here they are real
+> `PromptChain` agents and the loop is the real `ExternalLoop`.
+
+## The primitive
+
+```python
+from promptchain.patterns.agent_comms import agent, group, round_robin, quorum
+
+A = agent("A", "a cautious engineer")          # an agent = ONE line
+B = agent("B", "a ship-it product lead")
+C = agent("C", "an evidence-driven researcher")
+
+t = group([A, B, C], round_robin(), term=[quorum(3)]).run("Ship Friday?")
+for m in t:
+    print(m)                                    # A: … / B: … / C: …
+```
+
+## Taxonomy → construct
+
+| G | Pattern | Construct | One-liner |
+|---|---|---|---|
+| G1 | Dyad (1:1) | `dyad(a, b)` | `dyad(A, B, "Ship Friday?")` |
+| G2 | Sequential pipeline + carryover | `pipeline(agents)` | `pipeline([A,B,C]).run("idea…")` |
+| G3 | Moderated group | `group(...)` | `group([A,B,C], round_robin()).run("goal")` |
+| G4 | Speaker-selection menu | `round_robin` · `random_pick` · `manual` · `llm_auto` · `custom` | `group(agents, llm_auto(judge))` |
+| G5 | FSM transition graph | `fsm(graph, inner)` | `fsm({"A":["B"],"B":["C"],"C":["A"]}, round_robin())` |
+| G6 | Broadcast (fan-out/in) | `broadcast(agents, synth)` | `broadcast([A,B,C], S).run("payload")` |
+| G7 | Handoff / condition router | `router(rules, fallback)` + `keyword_rule` / `cond_rule` / `llm_rule` / `sel_from_router` | `router([keyword_rule(["data"], C)], B)` |
+| G8 | Nested encapsulation | `as_agent(name, inner_run, summarizer)` | wraps a whole group as ONE agent |
+| G9 | Shared blackboard | `MeshContext` | `ctx.vars["days_left"] = 2` |
+| G10 | Step-clock loop | `ExternalLoop` (drives `Group`) | bounded, un-disableable guard |
+| G11 | Accessibility gate | `AccessibilityGate` | `gate.can_reach("A", "C")` |
+| G12 | Termination / loop-break | `max_turns` · `quorum` · `stop_when` · `jaccard_repeat` | `term=[quorum(3)]` |
+
+## Selector menu (G4) — who speaks next
+
+```python
+from promptchain.patterns.agent_comms import round_robin, random_pick, manual, llm_auto, custom
+
+round_robin()               # strict cyclic order
+random_pick(seed=0)         # random, excluding the current speaker
+manual(["C", "A", "B"])     # explicit order; ends the loop when exhausted
+by_capability()             # STATIC: route to the agent whose declared capabilities fit the topic
+llm_auto(judge)             # a judge agent NAMES the next speaker  (only model-driven one)
+custom(fn)                  # any fn(last, agents, transcript, ctx) -> agent | None
+```
+
+Only `llm_auto` calls a model, and it is **async** (the group engine awaits it inside
+the `ExternalLoop`). All others are pure and free.
+
+## Routing (G7)
+
+```python
+from promptchain.patterns.agent_comms import router, keyword_rule, cond_rule, sel_from_router
+
+route = router([keyword_rule(["data"], C), keyword_rule(["risk"], A)], fallback=B)
+route("what does the data say?")            # -> C   (standalone handoff)
+group(agents, sel_from_router(route))       # -> use the router AS a group selector
+```
+
+Rules are tried in priority order. `keyword_rule` / `cond_rule` are model-free (safe
+inside a group loop); `llm_rule` calls a model synchronously — standalone use only.
+
+## Termination (G12)
+
+```python
+term = [quorum(3)]                          # stop once all 3 have spoken
+term = [max_turns(6), stop_when("AGREE")]   # …or after 6 turns, or on a token
+term = [jaccard_repeat(0.85)]               # …or when an agent repeats itself
+group(agents, round_robin(), term=term, max_turns=20)   # max_turns = hard ExternalLoop cap
+```
+
+## Nested encapsulation (G8)
+
+```python
+from promptchain.patterns.agent_comms import as_agent, group, round_robin
+
+summ = agent("Σ", "summarizes a sub-team into one recommendation")
+team = as_agent("Team", lambda: group([A, B, C], round_robin(), max_turns=3).run("x"), summ)
+# `team` composes like any agent — outsiders see only its one-line summary.
+```
+
+## Orchestrators — static vs agentic (match to your agents)
+
+The orchestrator (the "manager" that runs a group) is a tunable choice — the same
+static-vs-agentic axis, one level up. **Spend the intelligence where the participants
+don't have it:**
+
+| Participants | Orchestrator |
+|---|---|
+| capable agents (strong models) | static `group()` — or `orchestrator(authority="select")` |
+| mixed / a few bounded tasks | `orchestrator(authority="steer")` |
+| dumb agents (small / 1B) | smart: strong `model`, `authority="full"`, higher `max_internal_steps` |
+
+Both orchestrators route by **capability**: give agents `capabilities=[...]` and the
+static `by_capability()` selector picks by skill-match, while the agentic manager knows
+each agent's capabilities and — when a turn **raises a question but addresses no one** —
+forwards that open question to whoever can best answer it.
+
+```python
+from promptchain.patterns.agent_comms import group, by_capability, quorum, orchestrator, captain
+
+A = agent("A", "security eng", capabilities=["security", "risk"])
+C = agent("C", "researcher", capabilities=["data", "churn"], tools=[lookup_metric])
+
+# STATIC orchestrator — capability-aware, deterministic, no model in the loop:
+group([A, B, C], by_capability(), term=[quorum(3)]).run("We found a vulnerability")
+
+# AGENTIC orchestrator — a manager AGENT (ASP) runs the group (AG2 GroupChatManager):
+boss = orchestrator("Boss", model="openai/gpt-4o", authority="steer")  # smart, for dumb agents
+t = boss.run_group([A, B, C], "what's our churn, and is Friday risky?")  # open Q -> routed to C
+#   authority: "select" (pick next speaker) | "steer" (+ per-turn directive) | "full" (+ synthesis)
+
+# CAPTAIN — a manager that runs a sub-team and presents as ONE agent (AG2 CaptainAgent, G8):
+team_lead = captain("Legal", [counsel_a, counsel_b], goal="Assess the contract risk.")
+group([team_lead, product, eng], round_robin()).run("Approve the deal?")
+```
+
+The manager is itself a true `AgenticStepProcessor`; its `model` + `max_internal_steps`
+ARE the "orchestrator intelligence" knob. `Orchestrator.run_group_async` exists for
+nesting inside another loop (a `captain` used in an outer agentic group).
+
+## Testing without a model
+
+`EchoAgent` is a deterministic, no-LLM agent — use it to test control flow for free:
+
+```python
+from promptchain.patterns.agent_comms import EchoAgent, group, round_robin
+A, B, C = EchoAgent("A"), EchoAgent("B"), EchoAgent("C")
+t = group([A, B, C], round_robin(), max_turns=4).run("go")
+assert [m.role for m in t if m.role != "Facilitator"] == ["A", "B", "C", "A"]
+```
+
+See `tests/test_agent_comms.py` (13 offline tests) and `examples/agent_comms_demo.py`
+(live, real `PromptChain` workers on `gpt-4o-mini`).
+
+## Design mandate
+
+Static, non-agentic — no `AgenticStepProcessor` for control flow. Selectors,
+routers, FSM edges, and stop predicates are Callables / boolean forks; the only model
+calls are (a) an agent generating its line and (b) the optional `llm_auto` selector.
+"""

--- a/promptchain/patterns/agent_comms/__init__.py
+++ b/promptchain/patterns/agent_comms/__init__.py
@@ -1,0 +1,70 @@
+"""Agent-communication patterns for PromptChain — agentic participants, static mesh.
+
+Every way agents talk to each other. Each *agent* is a real
+:class:`~promptchain.utils.agentic_step_processor.AgenticStepProcessor` (its own
+internal reason-act loop, can call tools); each *pattern* is a few lines over
+``say``/``respond``, with a **Callable** — never a model — deciding who-speaks-next and
+when-to-stop. R-PC1/R-PC2 governs the mesh, not the agents; PromptChain does BOTH static
+and agentic, both first-class.
+
+Taxonomy → construct
+--------------------
+======  =========================  =================================================
+G       pattern                    construct here
+======  =========================  =================================================
+G1      dyad (1:1)                 :func:`dyad`  (= a group over two agents)
+G2      sequential pipeline        :func:`pipeline`
+G3      moderated group            :func:`group` / :class:`Group`
+G4      speaker-selection menu     :func:`round_robin` :func:`random_pick`
+                                    :func:`manual` :func:`llm_auto` :func:`custom`
+G5      FSM transition graph       :func:`fsm`
+G6      broadcast (fan-out/in)     :func:`broadcast`
+G7      handoff / condition router :func:`router` (+ :func:`keyword_rule`,
+                                    :func:`cond_rule`, :func:`llm_rule`,
+                                    :func:`sel_from_router`)
+G8      nested encapsulation       :func:`as_agent`
+G9      shared blackboard          :class:`MeshContext`
+G10     step-clock loop            :class:`ExternalLoop` (drives :class:`Group`)
+G11     accessibility gate         :class:`AccessibilityGate`
+G12     termination / loop-break   :func:`max_turns` :func:`quorum`
+                                    :func:`stop_when` :func:`jaccard_repeat`
+======  =========================  =================================================
+
+Quick start
+-----------
+    from promptchain.patterns.agent_comms import agent, group, round_robin, quorum
+
+    A = agent("A", "a cautious engineer")
+    B = agent("B", "a ship-it product lead")
+    C = agent("C", "an evidence-driven researcher")
+
+    t = group([A, B, C], round_robin(), term=[quorum(3)]).run("Ship Friday?")
+    for m in t: print(m)
+"""
+from promptchain.utils.external_loop import ExternalLoop  # G10 (re-exported)
+
+from .agents import DEFAULT_MODEL, EchoAgent, LLMAgent, agent
+from .orchestrator import Orchestrator, captain, orchestrator
+from .patterns import Group, as_agent, broadcast, dyad, group, pipeline
+from .routing import cond_rule, keyword_rule, llm_rule, router, sel_from_router
+from .selectors import (by_capability, custom, fsm, llm_auto, manual,
+                        random_pick, round_robin)
+from .termination import jaccard_repeat, max_turns, quorum, stop_when
+from .types import AccessibilityGate, MeshContext, Msg, render, speakers
+
+__all__ = [
+    # agents
+    "agent", "LLMAgent", "EchoAgent", "DEFAULT_MODEL",
+    # patterns
+    "group", "Group", "dyad", "pipeline", "broadcast", "as_agent",
+    # orchestrators (static group() above; agentic manager agent here)
+    "orchestrator", "Orchestrator", "captain",
+    # selectors (G4) + fsm (G5) + capability-based (static routing)
+    "round_robin", "random_pick", "manual", "llm_auto", "custom", "fsm", "by_capability",
+    # routing (G7)
+    "router", "keyword_rule", "cond_rule", "llm_rule", "sel_from_router",
+    # termination (G12)
+    "max_turns", "quorum", "stop_when", "jaccard_repeat",
+    # types (G9 / G11) + loop (G10)
+    "Msg", "MeshContext", "AccessibilityGate", "render", "speakers", "ExternalLoop",
+]

--- a/promptchain/patterns/agent_comms/agents.py
+++ b/promptchain/patterns/agent_comms/agents.py
@@ -1,0 +1,154 @@
+"""Agents — each participant is a TRUE agent (an ``AgenticStepProcessor``).
+
+An agent is NOT a single-shot LLM call. Each turn runs the agent's own internal
+reason-act loop (``AgenticStepProcessor``, up to ``max_internal_steps`` LLM calls,
+with tools) and returns only its final answer — the ASP's history is internally
+isolated, so it never bloats the conversation.
+
+This is the correct split (house note ``feedback-static-not-agentic-promptchain``:
+static IS scoped to one experiment; *"PromptChain does BOTH static and agentic, both
+first-class"*):
+    * the MESH / control flow (who-speaks-next, when-to-stop) is STATIC — pure
+      Callables in selectors.py / routing.py / termination.py. A model never drives it.
+    * each PARTICIPANT is AGENTIC — a real agent per turn. That is what makes this a
+      multi-AGENT system rather than a multi-prompt one.
+
+Give an agent ``tools=[plain_func]`` and it genuinely acts: the schema is auto-derived
+and the ASP can call the function inside its loop.
+
+``EchoAgent`` is a deterministic, no-LLM stand-in so control flow is testable for free.
+"""
+from __future__ import annotations
+
+import inspect
+from typing import Callable, List, Optional
+
+from promptchain import PromptChain
+from promptchain.utils.agentic_step_processor import AgenticStepProcessor
+
+from .types import Msg, Transcript, render
+
+DEFAULT_MODEL = "openai/gpt-4o-mini"
+
+
+def _tool_schema(func: Callable) -> dict:
+    """Auto-derive an OpenAI/litellm tool schema from a plain function's signature +
+    docstring. Params are typed as strings (good enough for simple tools) — override by
+    passing a full schema via ``add_tools`` yourself if you need richer types."""
+    props, required = {}, []
+    for pname, p in inspect.signature(func).parameters.items():
+        props[pname] = {"type": "string", "description": pname}
+        if p.default is inspect.Parameter.empty:
+            required.append(pname)
+    desc = (func.__doc__ or func.__name__).strip().split("\n")[0]
+    return {"type": "function", "function": {
+        "name": func.__name__, "description": desc,
+        "parameters": {"type": "object", "properties": props, "required": required}}}
+
+
+class LLMAgent:
+    """A true agent: an ``AgenticStepProcessor`` wrapped as a discussion participant."""
+
+    def __init__(self, name: str, persona: str, model: str = DEFAULT_MODEL,
+                 tools: Optional[List[Callable]] = None, max_internal_steps: int = 4,
+                 one_sentence: bool = True, objective: Optional[str] = None,
+                 capabilities: Optional[List[str]] = None):
+        self.name = name
+        self.persona = persona
+        # Declared skills — used by capability-based selection (by_capability) and by an
+        # agentic orchestrator to route an open question to whoever can best answer it.
+        self.capabilities = list(capabilities or [])
+        turn = ("Contribute ONE short in-character sentence as your turn."
+                if one_sentence else "Contribute your turn.")
+        caps = f" Your areas: {', '.join(self.capabilities)}." if self.capabilities else ""
+        # A goal definition (not a conversational message) — per recipe-agentic-step.
+        # `objective` overrides the default participant role (used to build a manager/
+        # orchestrator agent, whose role is to run the group, not to participate).
+        self.objective = objective or (
+            f"You are {name}, {persona}.{caps} You are ONE participant in a multi-agent "
+            f"discussion. Read the conversation provided as your input, reason "
+            f"step-by-step internally (call a tool if it helps), then {turn} "
+            f"Return ONLY your turn text — no name prefix, no narration, no quotes.")
+        self.asp = AgenticStepProcessor(
+            objective=self.objective,
+            model_name=model,
+            max_internal_steps=max_internal_steps,
+            history_mode="progressive",   # better multi-hop reasoning than "minimal"
+        )
+        # ASP carries its own model → the parent chain needs no model slot.
+        self.chain = PromptChain(models=[], instructions=[self.asp])
+        self.tools = list(tools or [])
+        for fn in self.tools:
+            self.chain.add_tools([_tool_schema(fn)])   # schema → the model SEES the tool
+            self.chain.register_tool_function(fn)       # implementation the loop calls
+
+    def _clean(self, raw: str) -> str:
+        s = raw.strip().replace("\n", " ")
+        prefix = f"{self.name}:"                         # strip a self-echoed "Name:" prefix
+        if s.lower().startswith(prefix.lower()):
+            s = s[len(prefix):].strip()
+        return s
+
+    # — conversational turn (reads transcript, runs the agent, appends its answer) —
+    def say(self, transcript: Transcript, ctx=None) -> str:
+        reply = self._clean(self.chain.process_prompt(render(transcript)))
+        transcript.append(Msg(self.name, reply))
+        return reply
+
+    async def say_async(self, transcript: Transcript, ctx=None) -> str:
+        reply = self._clean(await self.chain.process_prompt_async(render(transcript)))
+        transcript.append(Msg(self.name, reply))
+        return reply
+
+    # — single-shot response to a raw string (pipeline / broadcast) —
+    def respond(self, text: str) -> str:
+        return self._clean(self.chain.process_prompt(text))
+
+    async def respond_async(self, text: str) -> str:
+        return self._clean(await self.chain.process_prompt_async(text))
+
+
+def agent(name: str, persona: str, model: str = DEFAULT_MODEL,
+          tools: Optional[List[Callable]] = None, max_internal_steps: int = 4,
+          capabilities: Optional[List[str]] = None, **kw) -> LLMAgent:
+    """A true agent in one line::
+
+        A = agent("A", "a cautious engineer", capabilities=["risk", "security"])
+        C = agent("C", "a researcher", tools=[lookup_metric])   # give it real tools
+    """
+    return LLMAgent(name, persona, model=model, tools=tools,
+                    max_internal_steps=max_internal_steps, capabilities=capabilities, **kw)
+
+
+class EchoAgent:
+    """Deterministic, no-LLM agent for testing control flow.
+
+    ``script`` cycles canned replies per turn; default ``"<name>-N"``. Same
+    say/say_async/respond surface as :class:`LLMAgent`.
+    """
+
+    def __init__(self, name: str, script: Optional[List[str]] = None,
+                 capabilities: Optional[List[str]] = None):
+        self.name = name
+        self.capabilities = list(capabilities or [])
+        self._script = list(script or [])
+        self._i = 0
+
+    def _next(self) -> str:
+        v = self._script[self._i % len(self._script)] if self._script else f"{self.name}-{self._i}"
+        self._i += 1
+        return v
+
+    def say(self, transcript: Transcript, ctx=None) -> str:
+        v = self._next()
+        transcript.append(Msg(self.name, v))
+        return v
+
+    async def say_async(self, transcript: Transcript, ctx=None) -> str:
+        return self.say(transcript, ctx)
+
+    def respond(self, text: str) -> str:
+        return f"{self.name}({self._next()})"
+
+    async def respond_async(self, text: str) -> str:
+        return self.respond(text)

--- a/promptchain/patterns/agent_comms/orchestrator.py
+++ b/promptchain/patterns/agent_comms/orchestrator.py
@@ -1,0 +1,145 @@
+"""Agentic orchestrators — a MANAGER AGENT that runs a group.
+
+Opt-in alternative to the static :func:`~promptchain.patterns.agent_comms.group`. The
+orchestrator is itself a true agent (an ``AgenticStepProcessor``) whose model and
+reasoning depth ARE the "orchestrator intelligence" knob.
+
+**Match orchestrator intelligence to participant capability:**
+    * dumb agents (small/1B models) → a SMART orchestrator: strong ``model``, higher
+      ``max_internal_steps``, ``authority="steer"``/``"full"`` (it directs every turn).
+    * capable agents → a SIMPLE orchestrator: cheap model, ``authority="select"`` — or
+      skip the agentic orchestrator entirely and use the static ``group()``.
+
+Authority levels (how much the manager does):
+    * ``"select"`` — only picks the next speaker (+ detects DONE). Lightest.
+    * ``"steer"``  — select + injects a per-turn directive telling the speaker what to
+      focus on (this is how a smart orchestrator carries dumb agents).
+    * ``"full"``   — steer + writes the final synthesis. Most authority.
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from promptchain.utils.external_loop import ExternalLoop
+
+from .agents import DEFAULT_MODEL, LLMAgent
+from .types import MeshContext, Msg, Transcript, render
+
+_AUTHORITY = ("select", "steer", "full")
+_DEFAULT_PERSONA = "a decisive facilitator who keeps the group on task and knows when it is done"
+
+
+class Orchestrator:
+    """A manager agent that runs a group (AG2 ``GroupChatManager('auto')``)."""
+
+    def __init__(self, name: str, persona: str = _DEFAULT_PERSONA,
+                 model: str = DEFAULT_MODEL, max_internal_steps: int = 3,
+                 authority: str = "full", max_rounds: int = 8, manager=None):
+        if authority not in _AUTHORITY:
+            raise ValueError(f"authority must be one of {_AUTHORITY}")
+        self.name = name
+        self.authority = authority
+        self.max_rounds = max_rounds
+        # The manager is a true agent with an ORCHESTRATOR objective (it runs the team,
+        # it does NOT do their work). `model`/`max_internal_steps` = its intelligence.
+        self.manager = manager or LLMAgent(
+            name, persona, model=model, max_internal_steps=max_internal_steps,
+            one_sentence=False,
+            objective=(f"You are {name}, {persona}. You ORCHESTRATE a team of agents "
+                       f"toward a goal — you do NOT do their work yourself. Follow the "
+                       f"specific instruction in each input exactly and return ONLY what "
+                       f"it asks (a name, DONE, a directive, or a synthesis)."))
+
+    # — shared setup: build the transcript + the per-round async step —
+    def _prep(self, agents, goal, ctx):
+        ctx = ctx or MeshContext(participants=[a.name for a in agents])
+        by_name = {a.name: a for a in agents}
+        # roster with capabilities → the manager routes by what each agent can DO
+        roster = "; ".join(
+            f"{a.name} ({', '.join(getattr(a, 'capabilities', []) or ['general'])})"
+            for a in agents)
+        t: Transcript = [Msg("Facilitator", goal)]
+        steer = self.authority in ("steer", "full")
+
+        async def step(it, st) -> bool:
+            fmt = ("Reply EXACTLY as `NAME :: directive` (directive = the specific "
+                   "question/task for that agent to address), OR `DONE`."
+                   if steer else "Reply with the NAME of who speaks next, OR `DONE`.")
+            decision = (await self.manager.respond_async(
+                f"Team (name → capabilities): {roster}\nGoal: {goal}\n"
+                f"Conversation so far:\n{render(t)}\n\n"
+                f"Choose who speaks next:\n"
+                f"- If the LAST message directly addresses a specific agent, pick that agent.\n"
+                f"- If it raises a question or concern but leaves it UNADDRESSED (names no one), "
+                f"pick the agent whose capabilities best fit ANSWERING that open question.\n"
+                f"- If the goal is resolved, reply DONE.\n{fmt}")).strip()
+            if "done" in decision.lower():
+                return False
+            name_part, _, directive = decision.partition("::")
+            nxt = next((by_name[n] for n in by_name if n.lower() in name_part.lower()),
+                       agents[0])
+            if steer and directive.strip():
+                t.append(Msg(f"{self.name}→{nxt.name}", directive.strip()))
+            await nxt.say_async(t, ctx)
+            return True
+
+        return t, step
+
+    def _synth_prompt(self, goal, t) -> str:
+        return (f"Goal: {goal}\nDiscussion:\n{render(t)}\n\n"
+                f"Write the final decision/synthesis in 1-2 sentences.")
+
+    def run_group(self, agents, goal: str, ctx=None) -> Transcript:
+        """Run the group synchronously (top-level use)."""
+        t, step = self._prep(agents, goal, ctx)
+        ExternalLoop(max_iters=self.max_rounds).run_sync(step, {})
+        if self.authority == "full":
+            t.append(Msg(self.name, self.manager.respond(self._synth_prompt(goal, t))))
+        return t
+
+    async def run_group_async(self, agents, goal: str, ctx=None) -> Transcript:
+        """Async variant — use when the orchestrator runs INSIDE another loop (e.g. a
+        :func:`captain` nested in an outer group), to avoid nesting event loops."""
+        t, step = self._prep(agents, goal, ctx)
+        await ExternalLoop(max_iters=self.max_rounds).run(step, {})
+        if self.authority == "full":
+            t.append(Msg(self.name, await self.manager.respond_async(self._synth_prompt(goal, t))))
+        return t
+
+
+def orchestrator(name: str, persona: str = _DEFAULT_PERSONA, model: str = DEFAULT_MODEL,
+                 max_internal_steps: int = 3, authority: str = "full",
+                 max_rounds: int = 8, manager=None) -> Orchestrator:
+    """An agentic orchestrator (manager agent). See :class:`Orchestrator`.
+
+    >>> # dumb agents -> smart orchestrator that steers every turn:
+    >>> orchestrator("M", model="openai/gpt-4o", max_internal_steps=6, authority="full")
+    >>> # capable agents -> simple orchestrator:
+    >>> orchestrator("M", authority="select")
+    """
+    return Orchestrator(name, persona, model, max_internal_steps, authority, max_rounds, manager)
+
+
+def captain(name: str, team: List, goal: str,
+            persona: str = "a captain who runs a sub-team and reports ONE recommendation",
+            model: str = DEFAULT_MODEL):
+    """G8 nested orchestrator (AG2 ``CaptainAgent``): a manager that RUNS a sub-team and
+    presents to the outside world as ONE agent — only its synthesis escapes. Composes
+    like any agent (has ``name`` / ``say`` / ``say_async``)."""
+    orch = Orchestrator(name, persona, model=model, authority="full")
+
+    class _Captain:
+        def __init__(self):
+            self.name = name
+
+        def say(self, transcript: Transcript, ctx=None) -> str:
+            s = orch.run_group(team, goal, ctx)[-1].content
+            transcript.append(Msg(self.name, s))
+            return s
+
+        async def say_async(self, transcript: Transcript, ctx=None) -> str:
+            s = (await orch.run_group_async(team, goal, ctx))[-1].content
+            transcript.append(Msg(self.name, s))
+            return s
+
+    return _Captain()

--- a/promptchain/patterns/agent_comms/patterns.py
+++ b/promptchain/patterns/agent_comms/patterns.py
@@ -1,0 +1,128 @@
+"""The pattern factories — G1 dyad · G2 pipeline · G3 group · G6 broadcast · G8 nested.
+
+The engine is :class:`Group`, driven by :class:`ExternalLoop` (deterministic, with an
+un-disableable iteration guard = the G12 hard cap). ``dyad`` is just a group over two
+agents. ``pipeline`` and ``broadcast`` are straight-line (inherently bounded).
+Everything here is STATIC control flow: a Callable selector/stop decides flow, never a model.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Callable, List, Optional
+
+from promptchain.utils.external_loop import ExternalLoop
+
+from .selectors import round_robin
+from .types import Msg, MeshContext, Transcript, render
+
+
+class Group:
+    """G3 — a shared thread; each round a ``selector`` picks the next speaker until
+    a stop predicate fires or ``max_turns`` is hit. Runs synchronously to the caller;
+    async internally (workers use ``say_async`` under the ExternalLoop)."""
+
+    def __init__(self, agents, selector=None, term: Optional[List[Callable]] = None,
+                 on_turn: Optional[Callable] = None, max_turns: int = 8):
+        self.agents = list(agents)
+        self.selector = selector or round_robin()
+        self.term = list(term or [])
+        self.on_turn = on_turn
+        self.max_turns = max_turns
+
+    def run(self, goal: str, ctx: Optional[MeshContext] = None) -> Transcript:
+        ctx = ctx or MeshContext(participants=[a.name for a in self.agents])
+        t: Transcript = [Msg("Facilitator", goal)]
+        state = {"last": None}
+
+        async def step(it: int, st: dict) -> bool:
+            nxt = self.selector(st["last"], self.agents, t, ctx)
+            if inspect.isawaitable(nxt):          # llm_auto is async
+                nxt = await nxt
+            if nxt is None:
+                return False                      # selector ended the conversation
+            await nxt.say_async(t, ctx)
+            st["last"] = nxt
+            if self.on_turn:
+                self.on_turn(t[-1], ctx)
+            return not any(stop(t, ctx) for stop in self.term)
+
+        ExternalLoop(max_iters=self.max_turns).run_sync(step, state)
+        return t
+
+
+def group(agents, selector=None, term=None, on_turn=None, max_turns: int = 8) -> Group:
+    """A moderated group (G3). See :class:`Group`."""
+    return Group(agents, selector, term, on_turn, max_turns)
+
+
+def dyad(a, b, goal: str = "Begin.", term=None, max_turns: int = 6) -> Transcript:
+    """G1 — a 1:1 exchange = a group over two agents, alternating."""
+    return Group([a, b], round_robin(), term, max_turns=max_turns).run(goal)
+
+
+class _Pipeline:
+    def __init__(self, agents):
+        self.agents = list(agents)
+
+    def run(self, seed: str) -> str:
+        """G2 — each agent transforms the previous one's output (carryover)."""
+        out = seed
+        for a in self.agents:
+            out = a.respond(out)
+        return out
+
+
+def pipeline(agents) -> _Pipeline:
+    """G2 — sequential pipeline with carryover."""
+    return _Pipeline(agents)
+
+
+class _Broadcast:
+    def __init__(self, agents, synthesizer=None):
+        self.agents = list(agents)
+        self.synthesizer = synthesizer
+
+    def run(self, payload: str):
+        """G6 — fan the payload out to all agents at once, then (optionally) a
+        synthesizer merges the replies. Returns ``(replies, verdict)``."""
+        async def _fanout():
+            async def one(a):
+                return Msg(a.name, await a.respond_async(payload))
+            return await asyncio.gather(*[one(a) for a in self.agents])
+
+        replies = asyncio.run(_fanout())
+        verdict = None
+        if self.synthesizer is not None:
+            verdict = self.synthesizer.respond(render(replies))
+        return replies, verdict
+
+
+def broadcast(agents, synthesizer=None) -> _Broadcast:
+    """G6 — broadcast fan-out / fan-in."""
+    return _Broadcast(agents, synthesizer)
+
+
+def as_agent(name: str, inner_run: Callable, summarizer):
+    """G8 — wrap a whole group/callable as ONE agent. Outsiders see only the
+    summarized result; the inner discussion stays hidden (chains-are-functions).
+
+    ``inner_run`` is a zero-arg callable returning a transcript (or any object)."""
+    class _Nested:
+        def __init__(self):
+            self.name = name
+
+        def _summary(self) -> str:
+            inner = inner_run()
+            txt = render(inner) if isinstance(inner, list) else str(inner)
+            return summarizer.respond(txt)
+
+        def say(self, transcript: Transcript, ctx=None) -> str:
+            s = self._summary()
+            transcript.append(Msg(self.name, s))
+            return s
+
+        async def say_async(self, transcript: Transcript, ctx=None) -> str:
+            return self.say(transcript, ctx)
+
+    return _Nested()

--- a/promptchain/patterns/agent_comms/routing.py
+++ b/promptchain/patterns/agent_comms/routing.py
@@ -1,0 +1,58 @@
+"""G7 handoff / condition-based routing — pure Callables.
+
+A *rule* is ``(query, ctx) -> Agent | None``; a *router* tries rules in priority
+order and falls back. ``keyword_rule`` / ``cond_rule`` are model-free (safe inside a
+group loop via :func:`sel_from_router`). ``llm_rule`` calls a model synchronously —
+use it for standalone routing, not inside an ``ExternalLoop`` step (use
+:func:`~promptchain.patterns.agent_comms.selectors.llm_auto` there instead).
+"""
+from __future__ import annotations
+
+from typing import List
+
+
+def keyword_rule(words, target):
+    """Route to ``target`` if any keyword appears in the query."""
+    ws = [w.lower() for w in words]
+    return lambda query, ctx=None: target if any(w in query.lower() for w in ws) else None
+
+
+def cond_rule(predicate, target):
+    """Route to ``target`` if ``predicate(query, ctx)`` is truthy (e.g. a blackboard check)."""
+    return lambda query, ctx=None: target if predicate(query, ctx) else None
+
+
+def llm_rule(judge, question, target):
+    """Route to ``target`` if the judge answers yes to ``question`` about the query.
+    Synchronous — standalone use only (not inside a group loop)."""
+    def rule(query, ctx=None):
+        ans = judge.respond(f"{question}\n\nText: {query}\n\nAnswer yes or no only.").strip().lower()
+        return target if ans.startswith("y") else None
+
+    return rule
+
+
+def router(rules: List, fallback):
+    """Priority chain: first rule to return a target wins; else ``fallback``.
+
+    >>> route = router([keyword_rule(["data"], C), keyword_rule(["risk"], A)], B)
+    >>> route("what does the data say?")   # -> C
+    """
+    def route(query, ctx=None):
+        for rule in rules:
+            t = rule(query, ctx)
+            if t is not None:
+                return t
+        return fallback
+
+    return route
+
+
+def sel_from_router(route):
+    """Adapt a router into a G4 selector — routes on the LAST message's content."""
+    def pick(last, agents, transcript, ctx=None):
+        query = transcript[-1].content if transcript else ""
+        target = route(query, ctx)
+        return target if hasattr(target, "name") else None
+
+    return pick

--- a/promptchain/patterns/agent_comms/selectors.py
+++ b/promptchain/patterns/agent_comms/selectors.py
@@ -1,0 +1,111 @@
+"""G4 speaker-selection menu + G5 FSM — pure Callables.
+
+A selector has the signature::
+
+    selector(last, agents, transcript, ctx) -> Agent | None   (may be async)
+
+Returning ``None`` ends the group loop. Only ``llm_auto`` calls a model — and it is
+**async** because it runs inside an :class:`ExternalLoop` step; the group engine
+awaits it automatically.
+"""
+from __future__ import annotations
+
+import random as _random
+
+from .types import render
+
+
+def round_robin():
+    """Strict cyclic order = the order agents were listed."""
+    i = {"n": -1}
+
+    def pick(last, agents, transcript, ctx=None):
+        i["n"] = (i["n"] + 1) % len(agents)
+        return agents[i["n"]]
+
+    return pick
+
+
+def random_pick(seed: int = 0):
+    """Random next speaker (excluding the current one), seeded for reproducibility."""
+    rng = _random.Random(seed)
+
+    def pick(last, agents, transcript, ctx=None):
+        pool = [a for a in agents if a is not last] or list(agents)
+        return rng.choice(pool)
+
+    return pick
+
+
+def manual(order):
+    """Deterministic explicit order (a stand-in for a human picking next). Ends
+    the loop when the list is exhausted."""
+    q = list(order)
+
+    def pick(last, agents, transcript, ctx=None):
+        if not q:
+            return None
+        name = q.pop(0)
+        return next((a for a in agents if a.name == name), None)
+
+    return pick
+
+
+def llm_auto(judge):
+    """A judge agent NAMES who speaks next — the ONLY model-driven selector.
+    Async: the group engine awaits it inside the loop."""
+    async def pick(last, agents, transcript, ctx=None):
+        names = ", ".join(a.name for a in agents)
+        q = (f"Given the discussion, reply with ONLY the name of who should speak "
+             f"next ({names}) to move us forward.\n\n" + render(transcript))
+        choice = (await judge.respond_async(q)).strip()
+        for a in agents:
+            if a.name.lower() in choice.lower():
+                return a
+        return agents[0]
+
+    return pick
+
+
+def by_capability(default=None):
+    """STATIC capability-based selection: pick the agent whose declared
+    ``capabilities`` best match the current topic (the last message). Deterministic
+    (keyword overlap, no model) — this is how the static orchestrator picks order by
+    *what agents can do*. Ties / no match fall back to ``default`` (round-robin).
+
+    >>> A = agent("A", "...", capabilities=["risk", "security"])
+    >>> group(agents, by_capability())      # routes each turn to the fitting skill
+    """
+    fallback = default or round_robin()
+
+    def pick(last, agents, transcript, ctx=None):
+        topic = (transcript[-1].content if transcript else "").lower()
+        best, best_score = None, 0
+        for a in agents:
+            score = sum(1 for cap in getattr(a, "capabilities", []) if cap.lower() in topic)
+            if score > best_score:
+                best, best_score = a, score
+        return best if best is not None else fallback(last, agents, transcript, ctx)
+
+    return pick
+
+
+def custom(fn):
+    """Wrap any ``fn(last, agents, transcript, ctx)`` as a selector."""
+    return fn
+
+
+def fsm(graph, inner):
+    """G5 — constrain the candidate set to legal successors, then delegate to an
+    inner selector.
+
+    >>> sel = fsm({"A": ["B"], "B": ["C"], "C": ["A"]}, round_robin())
+    """
+    def pick(last, agents, transcript, ctx=None):
+        if last is None:
+            return agents[0]
+        legal_names = graph.get(last.name, [])
+        legal = [a for a in agents if a.name in legal_names] or list(agents)
+        return inner(last, legal, transcript, ctx)
+
+    return pick

--- a/promptchain/patterns/agent_comms/termination.py
+++ b/promptchain/patterns/agent_comms/termination.py
@@ -1,0 +1,40 @@
+"""G12 termination / loop-break — pure stop predicates.
+
+A stop predicate is ``(transcript, ctx) -> bool``; the group loop ends the moment
+any of them is True. The hard, un-disableable cap is the group's ``max_turns``
+(enforced by :class:`ExternalLoop`'s ``max_iters`` guard) — these predicates add the
+*semantic* stops on top.
+"""
+from __future__ import annotations
+
+from .types import speakers
+
+
+def max_turns(n: int):
+    """Stop after ``n`` agent turns (facilitator lines don't count)."""
+    return lambda transcript, ctx=None: len([m for m in transcript if m.role != "Facilitator"]) >= n
+
+
+def quorum(k: int):
+    """Stop once ``k`` distinct agents have spoken (everyone weighed in)."""
+    return lambda transcript, ctx=None: len(speakers(transcript)) >= k
+
+
+def stop_when(substring: str):
+    """Stop when the last message contains ``substring`` (e.g. an ``AGREE`` token)."""
+    s = substring.lower()
+    return lambda transcript, ctx=None: bool(transcript) and s in transcript[-1].content.lower()
+
+
+def jaccard_repeat(threshold: float = 0.85):
+    """Stop when an agent repeats itself (word-overlap of the last two turns >
+    ``threshold``) — the TinyTroupe-style runaway-chatter guard."""
+    def _jac(a: str, b: str) -> float:
+        A, B = set(a.lower().split()), set(b.lower().split())
+        return len(A & B) / len(A | B) if (A | B) else 0.0
+
+    def stop(transcript, ctx=None) -> bool:
+        msgs = [m for m in transcript if m.role != "Facilitator"]
+        return len(msgs) >= 2 and _jac(msgs[-1].content, msgs[-2].content) > threshold
+
+    return stop

--- a/promptchain/patterns/agent_comms/types.py
+++ b/promptchain/patterns/agent_comms/types.py
@@ -1,0 +1,62 @@
+"""Core data types for agent-communication patterns.
+
+A message stream is a plain ``list[Msg]``; a shared blackboard is ``MeshContext``
+(G9); an accessibility graph is ``AccessibilityGate`` (G11). Deliberately tiny —
+these are records, not machinery.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Set
+
+
+@dataclass
+class Msg:
+    """One line in a conversation. ``str(msg)`` renders ``"Role: content"``."""
+
+    role: str
+    content: str
+
+    def __str__(self) -> str:  # noqa: D401
+        return f"{self.role}: {self.content}"
+
+
+# A transcript is just a list of Msg — no wrapper class needed.
+Transcript = List[Msg]
+
+# The kickoff/system voice; excluded from "who has spoken" counts.
+FACILITATOR = "Facilitator"
+
+
+def render(transcript: Transcript) -> str:
+    """The transcript as a single string, ready to feed an agent."""
+    return "\n".join(str(m) for m in transcript) if transcript else "(open the discussion)"
+
+
+def speakers(transcript: Transcript) -> Set[str]:
+    """Distinct agent names that have spoken (excludes the facilitator)."""
+    return {m.role for m in transcript if m.role != FACILITATOR}
+
+
+@dataclass
+class MeshContext:
+    """G9 — the shared blackboard: state read/written out-of-band of the message
+    stream. Selectors and routers READ it; tools WRITE it."""
+
+    vars: Dict[str, Any] = field(default_factory=dict)
+    participants: List[str] = field(default_factory=list)
+
+
+@dataclass
+class AccessibilityGate:
+    """G11 — a relationship graph gating who may reach whom.
+
+    >>> g = AccessibilityGate({"A": {"B"}, "B": {"A", "C"}, "C": {"B"}})
+    >>> g.can_reach("A", "B"), g.can_reach("A", "C")
+    (True, False)
+    """
+
+    allowed: Dict[str, Set[str]]
+
+    def can_reach(self, src: str, dst: str) -> bool:
+        return dst in self.allowed.get(src, set())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "promptchain/_version.py"
-fallback_version = "0.6.1"
+fallback_version = "0.10.0"

--- a/tests/test_agent_comms.py
+++ b/tests/test_agent_comms.py
@@ -1,0 +1,157 @@
+"""Offline control-flow tests for promptchain.patterns.agent_comms.
+
+These use EchoAgent (no LLM) so the STATIC control flow — selection, FSM legality,
+termination, gating, routing — is proven deterministically, for free. The model is
+never exercised here; that's the point (control flow is not model-driven).
+"""
+from promptchain.patterns.agent_comms import (
+    AccessibilityGate, EchoAgent, Orchestrator, as_agent, broadcast, by_capability,
+    dyad, fsm, group, keyword_rule, manual, max_turns, pipeline, quorum,
+    round_robin, router, sel_from_router, speakers, stop_when,
+)
+
+
+def _abc():
+    return EchoAgent("A"), EchoAgent("B"), EchoAgent("C")
+
+
+def test_round_robin_order():
+    A, B, C = _abc()
+    t = group([A, B, C], round_robin(), max_turns=4).run("go")
+    assert [m.role for m in t if m.role != "Facilitator"] == ["A", "B", "C", "A"]
+
+
+def test_quorum_stops_after_all_spoke():
+    A, B, C = _abc()
+    t = group([A, B, C], round_robin(), term=[quorum(3)], max_turns=20).run("go")
+    # stops the moment the 3rd distinct speaker lands — exactly 3 turns, not 20
+    assert len([m for m in t if m.role != "Facilitator"]) == 3
+    assert speakers(t) == {"A", "B", "C"}
+
+
+def test_max_turns_hard_cap():
+    A, B, C = _abc()
+    t = group([A, B, C], round_robin(), max_turns=2).run("go")
+    assert len([m for m in t if m.role != "Facilitator"]) == 2
+
+
+def test_fsm_only_legal_successors():
+    A, B, C = _abc()
+    # A->B->C->A only; round-robin within the (single) legal set == the cycle
+    t = group([A, B, C], fsm({"A": ["B"], "B": ["C"], "C": ["A"]}, round_robin()),
+              max_turns=4).run("go")
+    assert [m.role for m in t if m.role != "Facilitator"] == ["A", "B", "C", "A"]
+
+
+def test_manual_order_and_exhaustion():
+    A, B, C = _abc()
+    t = group([A, B, C], manual(["C", "A"]), max_turns=10).run("go")
+    # manual list exhausts after 2 picks -> selector returns None -> loop ends
+    assert [m.role for m in t if m.role != "Facilitator"] == ["C", "A"]
+
+
+def test_stop_when_token():
+    A = EchoAgent("A", script=["thinking", "we AGREE now"])
+    B = EchoAgent("B", script=["hmm", "still unsure"])
+    t = group([A, B], round_robin(), term=[stop_when("agree")], max_turns=10).run("go")
+    assert "agree" in t[-1].content.lower()
+
+
+def test_dyad_alternates():
+    A, B, _ = _abc()
+    t = dyad(A, B, max_turns=4)
+    assert [m.role for m in t if m.role != "Facilitator"] == ["A", "B", "A", "B"]
+
+
+def test_pipeline_carryover():
+    A, B, C = _abc()
+    out = pipeline([A, B, C]).run("seed")
+    # each stage wraps the prior output -> nesting proves order A then B then C
+    assert out.startswith("C(") and "A" not in out[:2]  # last transform is C's
+
+
+def test_broadcast_fanout():
+    A, B, C = _abc()
+    replies, verdict = broadcast([A, B, C]).run("payload")
+    assert [m.role for m in replies] == ["A", "B", "C"]
+    assert verdict is None  # no synthesizer supplied
+
+
+def test_nested_encapsulation_hides_inner():
+    A, B, C = _abc()
+    summ = EchoAgent("Sum")
+    team = as_agent("Team", lambda: group([A, B, C], round_robin(), max_turns=3).run("x"), summ)
+    outer = []
+    team.say(outer)
+    assert len(outer) == 1 and outer[0].role == "Team"   # only ONE line escapes
+
+
+def test_router_keyword():
+    A, B, C = _abc()
+    route = router([keyword_rule(["data"], C), keyword_rule(["risk"], A)], fallback=B)
+    assert route("what does the data say?") is C
+    assert route("is there a risk?") is A
+    assert route("hello") is B
+
+
+def test_sel_from_router_in_group():
+    A, B, C = _abc()
+    route = router([keyword_rule(["A-0"], A)], fallback=B)  # matches A's first echo line
+    # first speaker is agents[0]=A (echoes "A-0"); router then routes on that -> A again
+    t = group([A, B, C], sel_from_router(route), max_turns=2).run("go")
+    assert [m.role for m in t if m.role != "Facilitator"][0] in {"A", "B"}
+
+
+def test_accessibility_gate():
+    g = AccessibilityGate({"A": {"B"}, "B": {"A", "C"}, "C": {"B"}})
+    assert g.can_reach("A", "B") is True
+    assert g.can_reach("A", "C") is False
+
+
+def test_orchestrator_full_authority():
+    # agentic orchestrator: a scripted "manager" picks speakers, stops on DONE, synthesizes
+    A, B, C = _abc()
+    mgr = EchoAgent("MGR", ["A :: think", "B :: think", "DONE"])
+    t = Orchestrator("Boss", manager=mgr, authority="full", max_rounds=10).run_group([A, B, C], "decide")
+    assert [m.role for m in t if m.role in {"A", "B", "C"}] == ["A", "B"]  # manager chose A then B
+    assert t[-1].role == "Boss"                                            # then wrote the synthesis
+
+
+def test_orchestrator_select_authority_no_synthesis():
+    A, B, C = _abc()
+    mgr = EchoAgent("MGR", ["A", "DONE"])
+    t = Orchestrator("Boss", manager=mgr, authority="select", max_rounds=10).run_group([A, B, C], "decide")
+    assert [m.role for m in t if m.role in {"A", "B", "C"}] == ["A"]
+    assert t[-1].role == "A"                                               # select => no synthesis line
+
+
+def test_by_capability_static_routing():
+    # static orchestrator picks the agent whose capabilities match the current topic
+    A = EchoAgent("A", capabilities=["risk", "security"])
+    B = EchoAgent("B", capabilities=["shipping", "launch"])
+    C = EchoAgent("C", capabilities=["data", "metrics"])
+    agents = [A, B, C]
+
+    def first(goal):
+        t = group(agents, by_capability(), max_turns=1).run(goal)
+        return [m.role for m in t if m.role in {"A", "B", "C"}][0]
+
+    assert first("We found a security vulnerability") == "A"
+    assert first("What does the data show?") == "C"
+    assert first("Time to plan the launch") == "B"
+    assert first("Hello everyone") == "A"            # no match -> round-robin fallback (first)
+
+
+if __name__ == "__main__":
+    import sys
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"FAIL {fn.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## What

New package **`promptchain.patterns.agent_comms`** — every agent-to-agent communication pattern as **static control flow with agentic participants**.

- **Agentic participants, static orchestration:** each agent is a true `AgenticStepProcessor` (own reason+tool loop, `tools=[...]`); the mesh (selector / router / termination) is pure Callables — a model never drives orchestration.
- **Patterns:** dyad · pipeline · group · broadcast · handoff router · FSM · nested (`as_agent`).
- **Tunable orchestrator** (match its intelligence to your agents): static `group()` + `by_capability()`, or an agentic manager agent `orchestrator()` (authority `select`/`steer`/`full`) with capability-aware **open-question forwarding**; `captain()` = a sub-team presented as one agent.
- **G4 selector menu** (round_robin / random / manual / llm_auto / custom) + **G5** `fsm`.
- `EchoAgent` for offline, no-LLM control-flow tests.

## Versioning

Cuts **v0.10.0** (minor feature bump from v0.9.3). CHANGELOG updated; `fallback_version` bumped.

## Verification

- **16/16 offline tests** (`tests/test_agent_comms.py`) — deterministic control flow via `EchoAgent`, no LLM.
- **Live**: every pattern + the agentic orchestrator run on `gpt-4o-mini` (`examples/agent_comms_demo.py`); the researcher agent's ASP actually calls its tool; the orchestrator routes an open question to the capability-matched agent.

Docs: `promptchain/patterns/agent_comms/README.md`. No secrets; no changes outside the new package + version files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
