### PR TITLE
feat(tui): /task — launch subagents to work a task (agent_comms)

### DIFF
--- a/docs/agent_comms_tui_task_command.md
+++ b/docs/agent_comms_tui_task_command.md
@@ -1,0 +1,126 @@
+# Design — `/task`: launch subagents for a task in the PromptChain TUI
+
+**Status:** DRAFT for approval (no code yet). **Repo:** `~/Documents/PromptChain`.
+**Depends on:** `promptchain.patterns.agent_comms` (v0.10.0, on `main`).
+
+## 1. Goal
+
+A TUI command that hands a **task** to the `agent_comms` **orchestrator**, which
+launches the participant **subagents**, routes the work by capability, streams each
+subagent's turn into the UI live, and commits the final synthesis to the chat. In one
+line: *type a task → watch a manager agent drive a team of subagents → get a result.*
+
+```
+/task "triage this stack trace and propose a fix"
+   Boss (orchestrator) → launches [analyst, coder, reviewer]
+   routes each open question to whoever can answer it (by capability)
+   each turn streams into the right-side dock; final synthesis → chat
+```
+
+## 2. User-facing surface
+
+Reuse the existing pattern-command arg parser (`_parse_pattern_command`, `app.py:2938`):
+
+```
+/task "<goal>" [--agents a,b,c] [--authority select|steer|full] [--rounds N] [--static]
+```
+
+- `"<goal>"` — the task (required).
+- `--agents a,b,c` — which subagents to launch. **Default:** all configured session
+  agents (`self.session.agents`). Each becomes an `agent_comms` participant.
+- `--authority` — orchestrator authority (default `steer`): `select` (pick next) ·
+  `steer` (+per-turn directive — best for weaker subagents) · `full` (+final synthesis).
+- `--rounds N` — max turns (hard cap; default 8).
+- `--static` — use the static orchestrator (`group()` + `by_capability()`) instead of
+  the agentic manager. Cheap/deterministic; no manager model calls.
+
+## 3. Flow
+
+1. `handle_command` sees `/task` → `_handle_task_command(command)` (new async method).
+2. Parse args; resolve the subagent roster from `self.session.agents` (or `--agents`).
+3. Build `agent_comms` participants from each session agent (name, persona/model,
+   `capabilities` — see §6). Build the orchestrator:
+   - agentic (default): `Orchestrator(name="Coordinator", authority=..., max_rounds=...)`
+   - static (`--static`): `group(participants, by_capability(), term=[...])`
+4. **Run without blocking the event loop** — `await orch.run_group_async(participants,
+   goal, ctx)`, wrapped in `asyncio.wait_for(..., timeout=turn_timeout)` exactly like the
+   existing `run_chat_turn_async` call (`app.py:4386-4404`). **Never** call the sync
+   `Orchestrator.run_group()` / `Group.run()` — both do `asyncio.run()` internally and
+   will raise `RuntimeError: asyncio.run() cannot be called from a running event loop`.
+5. Each completed subagent turn fires an `on_turn(msg, ctx)` callback → surfaced live
+   (§5). The final synthesis (authority `full`) → committed to `ChatView` as the answer.
+
+## 4. Where it hooks in (concrete)
+
+| Piece | Location |
+|---|---|
+| Dispatch | `handle_command` if/elif — add `elif command.startswith("/task"): await self._handle_task_command(command)` before the catch-all `else` at **`app.py:2926-2929`** |
+| Handler | new `async def _handle_task_command(self, command)` beside `_handle_branch_pattern` (~`app.py:2998`); reuse `_parse_pattern_command` (`app.py:2938`) |
+| Run | `await orch.run_group_async(...)` inside that handler (mirrors `handle_user_message` awaiting `run_chat_turn_async`, `app.py:4386`) |
+| Autocomplete | add `/task` to the InputWidget command list (same file family as the if/elif chain) |
+
+## 5. Live display — reuse the existing subagent surface
+
+The TUI **already** shows sub-agents: AgentChain router mode emits `plan_agent_start/
+complete` → `_orchestration_callback` (`app.py:1728`) → `_add_task_internal_step(...)`
+→ **`TaskListWidget`** (the right dock). We reuse that exact visual language:
+
+- Define a sync `_on_agent_task_turn(self, msg, ctx)` that does
+  `self._safe_call_ui(lambda: self._add_task_internal_step("tool_call", f"{msg.role} ▸ {msg.content}"))`.
+- `_safe_call_ui` (`app.py:393-410`) marshals the update onto the UI thread safely —
+  the sanctioned mechanism for any callback that might fire off-thread.
+- Pass it as the orchestrator's `on_turn`. So subagent turns land in the dock just like
+  today's router sub-agents; the final synthesis commits to `ChatView`.
+
+## 6. Subagent roster + capabilities
+
+- **Roster source:** `self.session.agents` (already managed by `/agent create|use|list`,
+  `app.py:2702-2894`) — each has `model_name` etc. `/task` turns these into participants.
+- **Capabilities:** `by_capability()` and the agentic manager both route by an agent's
+  declared `capabilities`. Session agents don't carry that field today → **add an optional
+  `capabilities` field to the session-agent record** (settable via `/agent create ...
+  --capabilities risk,security`), defaulting to `[]` (falls back to round-robin / manager
+  judgment). Small, additive.
+
+## 7. Prerequisites (small package changes — must land first)
+
+1. **Merge `main` (agent_comms v0.10.0) into the working branch.** The package is on
+   `main`; the TUI branch (`fix/tui-history-persistence`) doesn't have it yet, so
+   `from promptchain.patterns.agent_comms import ...` currently `ImportError`s there.
+2. **Add an `on_turn` hook to `Orchestrator`** (mirror `Group`'s): accept `on_turn` in
+   `__init__`, and call `self.on_turn(t[-1], ctx)` inside `_prep`'s `step()` right after
+   `await nxt.say_async(...)`. Today only `Group` has `on_turn`; the agentic orchestrator
+   needs it for live turn surfacing. (~5 lines, additive.)
+3. **(Phase 2) Forward `streaming_callback` through `LLMAgent`** into its
+   `AgenticStepProcessor` so we can stream *inside* a subagent's turn (thinking / tool
+   calls), not just per-completed-turn. Today `LLMAgent` threads no streaming callback →
+   turn-level granularity only.
+
+## 8. Phasing
+
+- **Phase 1 (MVP):** `/task` → agentic orchestrator over session agents, `--authority`/
+  `--rounds`/`--static` flags, **turn-level** display in the dock, synthesis to chat.
+  Needs prereqs 1 + 2.
+- **Phase 2:** intra-turn streaming (prereq 3), `--capabilities` wiring on `/agent
+  create`, a capability-aware `--static` default, optional `captain()` nesting for
+  sub-teams.
+
+## 9. Decisions (LOCKED 2026-07-12)
+
+1. **Roster default = ALL session agents.** `/task` launches every configured
+   `self.session.agents`; `--agents a,b,c` narrows.
+2. **Result = final synthesis in CHAT, full transcript in the DOCK** (not chat). Rationale:
+   putting every subagent turn in the chat log would bloat the conversation's token
+   window; the dock keeps the transcript out of the chat's context budget.
+3. **Default orchestrator = AGENTIC manager** (`authority="steer"`); `--static`
+   (`group()` + `by_capability()`) is the cheap/deterministic opt-out.
+4. **Doc home = repo `docs/`** (`docs/agent_comms_tui_task_command.md`), committed on the
+   implementation branch alongside the code.
+
+## 10. Risks / gotchas (already accounted for)
+
+- `asyncio.run()` trap → use `run_group_async` only (§3.4).
+- Long tasks blocking the UI → `asyncio.wait_for` timeout, same as existing turns.
+- Off-thread UI mutation → `_safe_call_ui` (§5).
+- Agentic orchestrator cost → each turn is an ASP loop + a manager decision; `--static`
+  and `--rounds` bound it; `--authority select` is the cheapest agentic option.

--- a/promptchain/cli/command_handler.py
+++ b/promptchain/cli/command_handler.py
@@ -236,6 +236,10 @@ COMMAND_REGISTRY: Dict[str, Dict[str, str]] = {
         "usage": '/speculate "context" [--min-confidence=0.7] [--prefetch=N]',
     },
     "/patterns": {"description": "Show pattern commands help", "usage": "/patterns"},
+    "/task": {
+        "description": "Launch subagents to work a task (agent_comms orchestrator)",
+        "usage": '/task "goal" [--authority=steer] [--rounds=8] [--agents=a,b,c] [--static]',
+    },
 }
 
 

--- a/promptchain/cli/tui/app.py
+++ b/promptchain/cli/tui/app.py
@@ -2926,6 +2926,9 @@ class PromptChainApp(App):
         elif command == "/patterns":
             await self._handle_patterns_help()
 
+        elif command.startswith("/task"):
+            await self._handle_task_command(command)
+
         else:
             from ..models import Message
 
@@ -2934,6 +2937,123 @@ class PromptChainApp(App):
                 content=f"Unknown command: {command}\nType /help for available commands.",
             )
             chat_view.add_message(error_msg)
+
+    async def _handle_task_command(self, command: str):
+        """Handle /task — launch subagents (an agent_comms orchestrator) to work a task.
+
+        Usage: /task "goal" [--authority=select|steer|full] [--rounds=8]
+                            [--agents=a,b,c] [--static]
+        Each configured session agent becomes a true agent_comms participant (an
+        AgenticStepProcessor). The agentic orchestrator (default) or the static
+        capability-router drives them; each completed turn streams to the task dock, and
+        only the final synthesis is committed to chat (turns stay in the dock to avoid
+        bloating the conversation context).
+        """
+        from ..models import Message
+
+        chat_view = self.query_one("#chat-view", ChatView)
+
+        try:
+            from promptchain.patterns.agent_comms import (
+                agent as make_agent,
+                orchestrator,
+                group,
+                by_capability,
+                max_turns,
+            )
+        except ImportError as e:
+            chat_view.add_message(Message(role="system", content=f"✗ agent_comms unavailable: {e}"))
+            return
+
+        parsed = self._parse_pattern_command(command)
+        if parsed["error"]:
+            chat_view.add_message(Message(
+                role="system",
+                content=(f"Error: {parsed['error']}\n"
+                         'Usage: /task "goal" [--authority=steer] [--rounds=8] [--agents=a,b,c] [--static]'),
+            ))
+            return
+        goal = parsed["query"]
+        opts = parsed["options"]
+
+        # Roster: all configured session agents, or a subset via --agents=a,b,c
+        if not self.session or not self.session.agents:
+            chat_view.add_message(Message(
+                role="system",
+                content="No agents configured. Create some with /agent create <name> ... first.",
+            ))
+            return
+        wanted = opts.get("agents")
+        if isinstance(wanted, str):
+            wanted = [wanted]
+        roster = [a for n, a in self.session.agents.items() if not wanted or n in wanted]
+        if len(roster) < 2:
+            avail = ", ".join(self.session.agents)
+            chat_view.add_message(Message(
+                role="system",
+                content=f"/task needs at least 2 agents (got {len(roster)}). Available: {avail}",
+            ))
+            return
+
+        # Map each session Agent -> an agent_comms participant (a true AgenticStepProcessor).
+        def _persona(a):
+            if getattr(a, "instruction_chain", None):
+                p = a.instruction_chain[0]
+                return p if isinstance(p, str) else str(p)
+            return getattr(a, "description", "") or f"an agent named {a.name}"
+
+        participants = [
+            make_agent(
+                name=a.name,
+                persona=_persona(a),
+                model=a.model_name,
+                capabilities=(getattr(a, "metadata", None) or {}).get("capabilities", []),
+            )
+            for a in roster
+        ]
+
+        # default "full" so the manager both steers each turn AND writes a final
+        # synthesis (the synthesis is what we commit to chat — locked decision).
+        authority = opts.get("authority", "full")
+        if authority not in ("select", "steer", "full"):
+            authority = "full"
+        rounds = int(opts.get("rounds", 8))
+        use_static = bool(opts.get("static", False))
+
+        # Stream each COMPLETED subagent turn into the task dock (NOT chat).
+        def on_turn(msg, ctx):
+            self._add_task_internal_step("tool_call", f"{msg.role} ▸ {msg.content}")
+
+        names = ", ".join(a.name for a in participants)
+        mode = "static · by-capability" if use_static else f"agentic manager · {authority}"
+        chat_view.add_message(Message(
+            role="system",
+            content=f"▸ /task — {len(participants)} subagents [{names}] · {mode}\n  goal: {goal}",
+        ))
+
+        try:
+            # MUST use the async variants — the sync run()/run_group() call asyncio.run()
+            # internally and would crash inside the Textual event loop.
+            if use_static:
+                transcript = await group(
+                    participants, by_capability(), term=[max_turns(rounds)],
+                    on_turn=on_turn, max_turns=rounds,
+                ).run_async(goal)
+            else:
+                transcript = await orchestrator(
+                    "Coordinator", authority=authority, max_rounds=rounds, on_turn=on_turn,
+                ).run_group_async(participants, goal)
+
+            synthesis = transcript[-1].content if transcript else "(no output)"
+            result_msg = Message(role="assistant", content=synthesis)
+            chat_view.add_message(result_msg)
+            self._add_task_internal_step("tool_result", f"task complete · {len(transcript)} turns")
+            if self.session:
+                self.session.messages.append(Message(role="user", content=command))
+                self.session.messages.append(result_msg)
+        except Exception as e:
+            chat_view.add_message(Message(role="system", content=f"✗ /task error: {e}"))
+            self._add_task_internal_step("error", str(e))
 
     def _parse_pattern_command(self, command: str) -> dict:
         """Parse pattern command into query and options.

--- a/promptchain/patterns/agent_comms/orchestrator.py
+++ b/promptchain/patterns/agent_comms/orchestrator.py
@@ -34,12 +34,16 @@ class Orchestrator:
 
     def __init__(self, name: str, persona: str = _DEFAULT_PERSONA,
                  model: str = DEFAULT_MODEL, max_internal_steps: int = 3,
-                 authority: str = "full", max_rounds: int = 8, manager=None):
+                 authority: str = "full", max_rounds: int = 8, manager=None,
+                 on_turn=None):
         if authority not in _AUTHORITY:
             raise ValueError(f"authority must be one of {_AUTHORITY}")
         self.name = name
         self.authority = authority
         self.max_rounds = max_rounds
+        # Optional per-completed-turn callback `on_turn(msg, ctx)` (mirrors Group) — used
+        # to stream each subagent's turn to a UI live (e.g. the TUI /task dock).
+        self.on_turn = on_turn
         # The manager is a true agent with an ORCHESTRATOR objective (it runs the team,
         # it does NOT do their work). `model`/`max_internal_steps` = its intelligence.
         self.manager = manager or LLMAgent(
@@ -81,6 +85,8 @@ class Orchestrator:
             if steer and directive.strip():
                 t.append(Msg(f"{self.name}→{nxt.name}", directive.strip()))
             await nxt.say_async(t, ctx)
+            if self.on_turn:
+                self.on_turn(t[-1], ctx)
             return True
 
         return t, step
@@ -109,15 +115,18 @@ class Orchestrator:
 
 def orchestrator(name: str, persona: str = _DEFAULT_PERSONA, model: str = DEFAULT_MODEL,
                  max_internal_steps: int = 3, authority: str = "full",
-                 max_rounds: int = 8, manager=None) -> Orchestrator:
+                 max_rounds: int = 8, manager=None, on_turn=None) -> Orchestrator:
     """An agentic orchestrator (manager agent). See :class:`Orchestrator`.
 
     >>> # dumb agents -> smart orchestrator that steers every turn:
     >>> orchestrator("M", model="openai/gpt-4o", max_internal_steps=6, authority="full")
     >>> # capable agents -> simple orchestrator:
     >>> orchestrator("M", authority="select")
+    >>> # stream each turn to a UI:
+    >>> orchestrator("M", on_turn=lambda msg, ctx: dock.add(f"{msg.role}: {msg.content}"))
     """
-    return Orchestrator(name, persona, model, max_internal_steps, authority, max_rounds, manager)
+    return Orchestrator(name, persona, model, max_internal_steps, authority, max_rounds,
+                        manager, on_turn)
 
 
 def captain(name: str, team: List, goal: str,

--- a/promptchain/patterns/agent_comms/patterns.py
+++ b/promptchain/patterns/agent_comms/patterns.py
@@ -30,7 +30,7 @@ class Group:
         self.on_turn = on_turn
         self.max_turns = max_turns
 
-    def run(self, goal: str, ctx: Optional[MeshContext] = None) -> Transcript:
+    def _prep(self, goal: str, ctx):
         ctx = ctx or MeshContext(participants=[a.name for a in self.agents])
         t: Transcript = [Msg("Facilitator", goal)]
         state = {"last": None}
@@ -47,7 +47,19 @@ class Group:
                 self.on_turn(t[-1], ctx)
             return not any(stop(t, ctx) for stop in self.term)
 
+        return t, state, step
+
+    def run(self, goal: str, ctx: Optional[MeshContext] = None) -> Transcript:
+        """Run synchronously (top-level / script use)."""
+        t, state, step = self._prep(goal, ctx)
         ExternalLoop(max_iters=self.max_turns).run_sync(step, state)
+        return t
+
+    async def run_async(self, goal: str, ctx: Optional[MeshContext] = None) -> Transcript:
+        """Async variant — use when running INSIDE an event loop (e.g. a Textual TUI),
+        where the sync ``run()`` would ``asyncio.run()`` a second loop and crash."""
+        t, state, step = self._prep(goal, ctx)
+        await ExternalLoop(max_iters=self.max_turns).run(step, state)
         return t
 
 

--- a/tests/test_agent_comms.py
+++ b/tests/test_agent_comms.py
@@ -142,6 +142,16 @@ def test_by_capability_static_routing():
     assert first("Hello everyone") == "A"            # no match -> round-robin fallback (first)
 
 
+def test_orchestrator_on_turn_hook():
+    # on_turn fires once per completed subagent turn (used to stream to a UI / TUI dock)
+    A, B, C = _abc()
+    mgr = EchoAgent("MGR", ["A :: x", "B :: x", "DONE"])
+    seen = []
+    Orchestrator("Boss", manager=mgr, authority="steer", max_rounds=10,
+                 on_turn=lambda msg, ctx: seen.append(msg.role)).run_group([A, B, C], "go")
+    assert seen == ["A", "B"]
+
+
 if __name__ == "__main__":
     import sys
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]

--- a/tests/test_agent_comms.py
+++ b/tests/test_agent_comms.py
@@ -152,6 +152,14 @@ def test_orchestrator_on_turn_hook():
     assert seen == ["A", "B"]
 
 
+def test_group_run_async():
+    # run_async runs on the current event loop (for TUIs); same result as sync run
+    import asyncio
+    A, B, C = _abc()
+    t = asyncio.run(group([A, B, C], round_robin(), max_turns=3).run_async("go"))
+    assert [m.role for m in t if m.role in {"A", "B", "C"}] == ["A", "B", "C"]
+
+
 if __name__ == "__main__":
     import sys
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]


### PR DESCRIPTION
## What

Adds a **`/task`** command to the TUI that launches **subagents** to work a task, using `agent_comms`:

```
/task "goal" [--authority=select|steer|full] [--rounds=N] [--agents=a,b,c] [--static]
```

Each configured **session agent** becomes a true `agent_comms` participant (an `AgenticStepProcessor`). The **agentic Orchestrator** (default `authority=full`: steers each turn + writes a synthesis) or the **static `by_capability`** router drives them. Each completed turn streams to the **`TaskListWidget` dock**; only the **final synthesis** is committed to chat (turns stay in the dock to avoid bloating the conversation context).

## Changes

- `app.py`: `/task` dispatch + `_handle_task_command`. Uses the async `run_group_async` / `run_async` — **never** the sync `run()`/`run_group()` (they `asyncio.run()` a second loop and crash Textual). Streams via `_add_task_internal_step`; roster/arg validation + graceful errors; persists to `session.messages`.
- `command_handler.py`: `/task` in `COMMAND_REGISTRY` (autocomplete).
- `patterns.py`: `Group.run_async` (mirrors `Orchestrator`) so `--static` works on the event loop; `Orchestrator.on_turn` hook added in the prior commit.
- `docs/agent_comms_tui_task_command.md`: the design.

## Verification

- **18/18** offline `agent_comms` tests (`tests/test_agent_comms.py`), incl. new `Orchestrator.on_turn` + `Group.run_async`.
- A **headless drive of the real `_handle_task_command`** (fake UI, real `gpt-4o-mini`) exercises the agentic + static + error paths: synthesis→chat, turns→dock, persistence all correct.
- ⏳ **Pending live TUI sanity-check** before merge.

## Try it live (from the worktree)

```
cd ~/Documents/PromptChain.wt-agent-comms-tui
PYTHONPATH=$PWD python3 -m promptchain.cli.main      # launch the TUI from the worktree
# create 2+ agents (your usual /agent create ...), then:
/task "should we ship Friday?" --rounds=3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
