### PR TITLE
feat(tui): --resume flag (default fresh) + harden deleted-cwd crash

### DIFF
--- a/promptchain/cli/main.py
+++ b/promptchain/cli/main.py
@@ -211,6 +211,13 @@ def setup_logging(
     help="Model to start the session with (overrides the active agent's model, "
     "e.g., 'openai/gpt-4o' or 'ollama/qwen3'). Applies for this launch only.",
 )
+@click.option(
+    "--resume",
+    is_flag=True,
+    default=False,
+    help="Resume the session's prior conversation. Default: start FRESH — a session "
+    "never replays its history unless you pass --resume.",
+)
 @click.version_option(version=__version__, prog_name="promptchain")
 @click.pass_context
 def main(
@@ -221,6 +228,7 @@ def main(
     verbose: bool,
     dev: bool,
     model: Optional[str],
+    resume: bool,
 ):
     """PromptChain - Interactive terminal interface for LLM conversations.
 
@@ -255,7 +263,7 @@ def main(
 
     # If no subcommand invoked, launch the TUI (default behavior)
     if ctx.invoked_subcommand is None:
-        _launch_tui(session, sessions_dir, config, verbose, dev, model)
+        _launch_tui(session, sessions_dir, config, verbose, dev, model, resume)
 
 
 @track_session()
@@ -266,6 +274,7 @@ def _launch_tui(
     verbose: bool,
     dev: bool,
     model: Optional[str] = None,
+    resume: bool = False,
 ):
     """Launch the interactive TUI application."""
     # Initialize MLflow observability
@@ -328,6 +337,7 @@ def _launch_tui(
                     config=base_config,  # Config already includes settings from YAML
                     verbose_mode=verbose,  # T118: Verbose observability mode
                     model_override=model,  # CLI --model: override agent model this launch
+                    resume=resume,  # --resume: replay prior history (default: fresh)
                 )
         except ImportError as e:
             raise click.ClickException(

--- a/promptchain/cli/tui/app.py
+++ b/promptchain/cli/tui/app.py
@@ -241,6 +241,7 @@ class PromptChainApp(App):
         config: Optional["Config"] = None,
         verbose_mode: bool = False,
         model_override: Optional[str] = None,
+        resume: bool = False,
         *args,
         **kwargs,
     ):
@@ -256,6 +257,9 @@ class PromptChainApp(App):
         """
         super().__init__(*args, **kwargs)
         self.session_name = session_name
+        # --resume: replay the session's prior conversation on startup. Default False —
+        # a session NEVER resumes its history unless explicitly asked (user preference).
+        self.resume = resume
         self.verbose_mode = verbose_mode  # T118: Verbose observability mode
         self.model_override = model_override  # CLI --model (this-launch override)
 
@@ -809,7 +813,12 @@ class PromptChainApp(App):
             else tool_count
         )
 
-        session_status = "New session created" if is_new_session else "Session loaded"
+        if is_new_session:
+            session_status = "New session created"
+        elif self.resume:
+            session_status = "Session resumed"
+        else:
+            session_status = "Session opened (fresh — use --resume to restore history)"
 
         # Wire config.performance.history_max_tokens to session
         self.session.history_max_tokens = self.config.performance.history_max_tokens
@@ -832,7 +841,21 @@ class PromptChainApp(App):
         # load so the banner is always the top item (fixes the welcome-in-the-
         # middle ordering bug on an existing session).
         chat_view = self.query_one("#chat-view", ChatView)
-        chat_view.load_messages([welcome_msg, *self.session.messages])
+        if self.resume:
+            # explicit opt-in: replay the full prior conversation beneath the banner
+            chat_view.load_messages([welcome_msg, *self.session.messages])
+        else:
+            # default: FRESH view — prior history is NOT replayed (still saved on disk,
+            # restorable with --resume). This is what the user always wants by default.
+            chat_view.load_messages([welcome_msg])
+            if self.session.messages:
+                chat_view.add_message(Message(
+                    role="system",
+                    content=(
+                        f"[dim]{len(self.session.messages)} prior message(s) hidden — "
+                        f"relaunch with --resume to restore them.[/dim]"
+                    ),
+                ))
 
         # Update status bar with active agent's model and router mode indicator (T039, T061)
         status_bar = self.query_one("#status-bar", StatusBar)

--- a/promptchain/observability/config.py
+++ b/promptchain/observability/config.py
@@ -49,10 +49,15 @@ def _get_config_file_path() -> Optional[Path]:
     Returns:
         Path to config file if found, None otherwise
     """
-    config_locations = [
-        Path.cwd() / ".promptchain.yml",
-        Path.home() / ".promptchain.yml",
-    ]
+    config_locations = []
+    try:
+        # Path.cwd() raises FileNotFoundError if the working directory was deleted
+        # (e.g. launched from a dir that no longer exists) — don't let that crash
+        # startup/shutdown; just skip the cwd-relative config location.
+        config_locations.append(Path.cwd() / ".promptchain.yml")
+    except (FileNotFoundError, OSError):
+        pass
+    config_locations.append(Path.home() / ".promptchain.yml")
 
     for config_path in config_locations:
         if config_path.exists():


### PR DESCRIPTION
## What

Two TUI fixes:

1. **`--resume` flag (default OFF).** A session **never replays its prior conversation** on startup unless you pass `--resume`. Default launch opens **fresh** — welcome banner only, plus a dim note showing how many prior messages are hidden and how to restore them. History is **never deleted** — it stays on disk, restorable with `--resume`.
   - Note: `save_session` rewrites `messages.jsonl` with `"w"`, so clearing the in-memory list would **wipe** history. This deliberately only gates the *display* (safe), threaded `main → _launch_tui → PromptChainApp(resume=...)`.
2. **Harden the deleted-cwd crash.** `Path.cwd()` raises `FileNotFoundError` when the working dir was deleted (e.g. launched from a removed worktree) — this crashed startup/shutdown (the ctrl-D exit error). Now caught; the cwd-relative config location is skipped instead of crashing.

## Verification

- Compiles; `--resume` appears in `--help`; deleted-cwd no longer crashes config resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
