### PR TITLE
fix(observability): tolerate all router return shapes in extract_routing_metadata

### DIFF
--- a/promptchain/observability/extractors.py
+++ b/promptchain/observability/extractors.py
@@ -10,6 +10,7 @@ FR-015: Automatic parameter extraction for MLflow tags
 """
 
 import inspect
+import json
 from typing import Any, Callable, Dict, List, Optional, Union
 
 
@@ -138,6 +139,31 @@ def extract_routing_metadata(params: Dict[str, Any]) -> Dict[str, Any]:
         'confidence', 'decision_confidence',
         'refined_query', 'router_reasoning'
     }
+
+    # Tolerate every shape a router can legitimately return.
+    #
+    # @track_routing passes the ROUTER'S RETURN VALUE here (decorators.py:404), and
+    # AgentChain's own function-router contract is to return a JSON *string* such as
+    # '{"chosen_agent": "miner"}'. That string reached `params[key]` and raised
+    # "TypeError: string indices must be integers"; a router returning None raised
+    # "TypeError: argument of type 'NoneType' is not iterable". Either killed the whole
+    # run through @track_routing's re-raise, so enabling observability broke any
+    # AgentChain(execution_mode="router") pipeline — observability must never be able to
+    # fail the thing it observes.
+    if params is None:
+        return {}
+    if isinstance(params, (bytes, bytearray)):
+        try:
+            params = params.decode("utf-8", "ignore")
+        except Exception:
+            return {}
+    if isinstance(params, str):
+        try:
+            params = json.loads(params)
+        except (ValueError, TypeError):
+            return {}          # free-text router output carries no structured decision
+    if not isinstance(params, dict):
+        return {}
 
     extracted = {}
     for key in routing_keys:

--- a/tests/test_observability_unit.py
+++ b/tests/test_observability_unit.py
@@ -12,6 +12,7 @@ Tests cover:
 
 import pytest
 import asyncio
+import json
 import time
 import os
 from unittest.mock import Mock, patch
@@ -768,6 +769,51 @@ def clean_context():
     set_current_run(None)
     yield
     set_current_run(None)
+
+
+class TestRoutingMetadataShapes:
+    """extract_routing_metadata must tolerate every shape a router can return.
+
+    Regression: @track_routing passes the ROUTER'S RETURN VALUE to this extractor
+    (decorators.py:404). AgentChain's function-router contract returns a JSON
+    *string* like '{"chosen_agent": "miner"}' — that reached `params[key]` and
+    raised "TypeError: string indices must be integers"; a router returning None
+    raised "TypeError: argument of type 'NoneType' is not iterable". @track_routing
+    re-raises, so merely enabling observability broke every
+    AgentChain(execution_mode="router") pipeline. Observability must never be able
+    to fail the thing it observes.
+    """
+
+    def test_dict_result_unchanged(self):
+        from promptchain.observability.extractors import extract_routing_metadata
+        out = extract_routing_metadata(
+            {"chosen_agent": "miner", "strategy": "single_agent_dispatch"})
+        assert out["chosen_agent"] == "miner"
+        assert out["strategy"] == "single_agent_dispatch"
+
+    def test_json_string_result_is_parsed(self):
+        """The AgentChain function-router contract shape."""
+        from promptchain.observability.extractors import extract_routing_metadata
+        out = extract_routing_metadata(json.dumps({"chosen_agent": "taste"}))
+        assert out["chosen_agent"] == "taste"
+
+    def test_none_result_returns_empty_not_raise(self):
+        from promptchain.observability.extractors import extract_routing_metadata
+        assert extract_routing_metadata(None) == {}
+
+    def test_free_text_result_returns_empty_not_raise(self):
+        from promptchain.observability.extractors import extract_routing_metadata
+        assert extract_routing_metadata("routing this to miner") == {}
+
+    def test_bytes_json_result_is_parsed(self):
+        from promptchain.observability.extractors import extract_routing_metadata
+        out = extract_routing_metadata(json.dumps({"chosen_agent": "reviser"}).encode())
+        assert out["chosen_agent"] == "reviser"
+
+    def test_non_mapping_json_returns_empty(self):
+        from promptchain.observability.extractors import extract_routing_metadata
+        assert extract_routing_metadata(json.dumps([1, 2, 3])) == {}
+        assert extract_routing_metadata(42) == {}
 
 
 # =============================================================================


### PR DESCRIPTION
Fixes #64.

Enabling MLflow observability crashed every `AgentChain(execution_mode="router")` pipeline at the first routing decision.

`@track_routing` passes the **router's return value** to `extract_routing_metadata` (`decorators.py:404`), but the extractor assumed a `dict`. AgentChain's own function-router contract returns a JSON **string**:

| router returns | before | after |
|---|---|---|
| `{"chosen_agent": "miner"}` | ok | ok (unchanged) |
| `'{"chosen_agent":"miner"}'` (the contract shape) | `TypeError: string indices must be integers` | parsed |
| `b'{"chosen_agent":"reviser"}'` | `TypeError` | parsed |
| `None` | `TypeError: ... NoneType is not iterable` | `{}` |
| free text / `[1,2,3]` / `42` | `TypeError` | `{}` |

`@track_routing` re-raises, so the failure propagated and killed the run — observed live as a run dying 74s in. **Observability must never be able to fail the thing it observes.**

## Why it was never caught

Every working observability example under `scripts/runs/` (incl. `2026-06-19_autoresearch/run.py`) builds plain `PromptChain` objects, and no run script combines `init_mlflow()` with `AgentChain`. The router + observability path had never been exercised together.

## Tests

Adds `TestRoutingMetadataShapes` — 6 cases (dict / JSON string / bytes / None / free text / non-mapping JSON), all passing.

Pre-existing unrelated failures in `test_observability_unit.py` (3× missing `pytest-asyncio`, 1× `test_config_defaults_when_not_set` expecting `localhost:5000` vs the `sqlite:///mlflow.db` default) are unchanged — verified by stashing the patch and re-running: identical 4 failures both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)