### PR TITLE
fix(agentic): bound the inner ReAct tool loop (max_tool_rounds)

### DIFF
--- a/promptchain/utils/agentic_step_processor.py
+++ b/promptchain/utils/agentic_step_processor.py
@@ -202,6 +202,7 @@ class AgenticStepProcessor:
         self,
         objective: str,
         max_internal_steps: int = 5,
+        max_tool_rounds: int = 40,
         model_name: Optional[str] = None,
         model_params: Optional[Dict[str, Any]] = None,
         history_mode: str = "minimal",
@@ -327,6 +328,15 @@ class AgenticStepProcessor:
 
         self.objective = objective
         self.max_internal_steps = max_internal_steps
+        # Hard bound on tool rounds within ONE agentic step. `max_internal_steps`
+        # bounds REASONING iterations only: after tools execute, the ReAct loop
+        # `continue`s without incrementing step_num (see the inner `while True`),
+        # so a model that keeps emitting tool calls is unbounded in wall-clock.
+        # Observed: a tool the model could not call correctly was retried 44 times
+        # at ~2-3s each, consuming a 20-minute job budget and producing nothing —
+        # every internal iteration counter still read "1/12". Default is ~3x the
+        # busiest legitimate step observed, so normal runs are unaffected.
+        self.max_tool_rounds = max(1, int(max_tool_rounds))
         self.model_name = model_name
         self.model_params = model_params or {}
         self.history_mode = history_mode
@@ -1069,6 +1079,7 @@ class AgenticStepProcessor:
         last_tool_msgs: List[Dict[str, Any]] = []
         clarification_attempts = 0
         max_clarification_attempts = 3
+        tool_rounds = 0          # bounds the inner ReAct loop (see self.max_tool_rounds)
 
         for step_num in range(self.max_internal_steps):
             # Check for interrupt request at start of each step
@@ -1853,6 +1864,29 @@ class AgenticStepProcessor:
                             )
 
                         # After tool(s) executed, continue inner while loop (do not increment step_num)
+                        # BOUND (see self.max_tool_rounds): step_num is deliberately not
+                        # incremented here, so without this counter the loop is unbounded —
+                        # a model stuck re-calling a tool it cannot call correctly spins
+                        # until the caller's wall-clock budget dies, with no error and the
+                        # iteration counter frozen at 1/N. Force a final answer instead.
+                        tool_rounds += 1
+                        if tool_rounds >= self.max_tool_rounds:
+                            logger.warning(
+                                f"[AgenticStepProcessor] Tool-round budget exhausted "
+                                f"({tool_rounds}/{self.max_tool_rounds}) in step "
+                                f"{step_num + 1}/{self.max_internal_steps}. The model kept "
+                                f"issuing tool calls without converging; forcing a final "
+                                f"answer. Raise max_tool_rounds if this is legitimate work."
+                            )
+                            internal_history.append({
+                                "role": "user",
+                                "content": (
+                                    "SYSTEM: tool-call budget exhausted for this step. Stop "
+                                    "calling tools and reply NOW with your final answer, "
+                                    "using only what you already have."
+                                ),
+                            })
+                            break      # leave the inner ReAct loop; the outer step continues
                         continue
                     else:
                         # No tool calls, check for content or clarify

--- a/tests/test_agentic_tool_round_bound.py
+++ b/tests/test_agentic_tool_round_bound.py
@@ -1,0 +1,98 @@
+"""AgenticStepProcessor must bound its inner ReAct tool loop.
+
+Regression: `max_internal_steps` bounds REASONING iterations only. After tools
+execute the loop `continue`s WITHOUT incrementing step_num, so a model that keeps
+emitting tool calls runs unbounded in wall-clock. Observed in the wild: a tool the
+model could not call correctly was retried 44 times at ~2-3s each, consuming a
+20-minute job budget and producing nothing — while every logged internal iteration
+still read "1/12", so the run looked healthy right up until the timeout.
+
+These tests drive run_async with an llm_runner that ALWAYS returns a tool call —
+i.e. a model that never converges — and assert termination.
+"""
+
+import asyncio
+import pytest
+
+from promptchain.utils.agentic_step_processor import AgenticStepProcessor
+
+
+class _ToolCall:
+    """Minimal LiteLLM-ish tool_call object."""
+    def __init__(self, i):
+        self.id = f"call_{i}"
+        self.type = "function"
+        self.function = type("F", (), {"name": "always_fails", "arguments": "{}"})()
+
+
+class _Msg:
+    """Assistant message that always requests another tool call."""
+    def __init__(self, i):
+        self.content = None
+        self.tool_calls = [_ToolCall(i)]
+        self.role = "assistant"
+
+
+TOOLS = [{
+    "type": "function",
+    "function": {
+        "name": "always_fails",
+        "description": "a tool the model can never satisfy",
+        "parameters": {"type": "object", "properties": {}},
+    },
+}]
+
+
+def _run(max_tool_rounds, max_internal_steps=3):
+    """Drive the processor with a never-converging model; return (result, calls)."""
+    calls = {"n": 0}
+
+    async def llm_runner(*a, **k):
+        calls["n"] += 1
+        return _Msg(calls["n"])
+
+    async def tool_executor(tool_call):
+        return "error: tool unavailable"
+
+    proc = AgenticStepProcessor(
+        objective="loop forever unless bounded",
+        max_internal_steps=max_internal_steps,
+        max_tool_rounds=max_tool_rounds,
+    )
+    result = asyncio.run(asyncio.wait_for(
+        proc.run_async("go", TOOLS, llm_runner, tool_executor),
+        timeout=30,          # the whole point: this must NOT be what stops it
+    ))
+    return result, calls["n"]
+
+
+def test_terminates_when_model_never_converges():
+    """Without the bound this never returns; with it, it must."""
+    result, n = _run(max_tool_rounds=4)
+    assert result is not None
+    # bounded per step, across at most max_internal_steps steps, plus the
+    # forced-final-answer call each step — generous ceiling, but FINITE.
+    assert n < 40, f"expected a bounded number of LLM calls, got {n}"
+
+
+def test_lower_bound_costs_fewer_calls():
+    """The budget is real: a tighter bound must do strictly less work."""
+    _, few = _run(max_tool_rounds=2)
+    _, many = _run(max_tool_rounds=8)
+    assert few < many, f"budget not enforced: {few} !< {many}"
+
+
+def test_budget_floor_is_at_least_one():
+    proc = AgenticStepProcessor(objective="x", max_tool_rounds=0)
+    assert proc.max_tool_rounds == 1
+    proc2 = AgenticStepProcessor(objective="x", max_tool_rounds=-5)
+    assert proc2.max_tool_rounds == 1
+
+
+def test_default_is_generous_enough_for_normal_work():
+    """Default must not throttle legitimate multi-tool steps (observed max ~12)."""
+    assert AgenticStepProcessor(objective="x").max_tool_rounds >= 30
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
`max_internal_steps` bounds **reasoning** iterations only. After tools execute, the ReAct loop `continue`s **without incrementing `step_num`** — so a model that keeps emitting tool calls is unbounded in wall-clock time.

## Observed in production

A tool the model could not call correctly (it flattened a JSON-payload argument into kwargs) was retried **44 times** at ~2-3s each. That consumed a 20-minute job budget and produced nothing.

The insidious part: because `step_num` never advanced, **every log line still read `internal iteration 1/12`**. No error, no convergence, no signal — the run looked healthy right up until the caller's timeout killed it.

## Fix

Adds `max_tool_rounds` (default **40** — roughly 3x the busiest legitimate step observed, so normal runs are unaffected). On exhaustion the processor:

1. logs a warning naming the budget and the step,
2. injects a `SYSTEM: tool-call budget exhausted … answer NOW` turn,
3. breaks the inner loop to force a final answer instead of spinning.

Fail-soft by design: the step still returns an answer, it just stops burning time.

## Tests

`tests/test_agentic_tool_round_bound.py` drives `run_async` with an `llm_runner` that **always** returns a tool call — a model that never converges:

- terminates at all (without the bound this never returns; the 30s `wait_for` in the test is a backstop, not the mechanism)
- a tighter budget does strictly less work (proves the budget is real, not cosmetic)
- `>= 1` floor for `0` / negative
- default stays generous enough for legitimate multi-tool steps

4 passed.

Pre-existing unrelated failures in the agentic test files (missing `pytest-asyncio`) are unchanged — verified by stashing the patch: **11 failed / 18 passed** before, **11 failed / 22 passed** after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)