### PR TITLE
fix(observability): record token usage for the shape PromptChain actually returns

### DIFF
--- a/promptchain/observability/decorators.py
+++ b/promptchain/observability/decorators.py
@@ -37,6 +37,7 @@ Usage:
 import time
 import logging
 import inspect
+from collections.abc import Mapping
 from functools import wraps
 from typing import Callable, Optional, List, Any, Dict
 
@@ -62,6 +63,70 @@ from .extractors import (
 from .mlflow_adapter import is_available, set_experiment
 
 logger = logging.getLogger(__name__)
+
+
+def _log_token_usage(result: Any, args: tuple) -> bool:
+    """Log prompt/completion/total token metrics for one LLM call. True if any logged.
+
+    Tries three shapes in order, because the ONE shape the original code handled is
+    the one PromptChain never actually produces:
+
+      1. ``result.usage``     — a raw LiteLLM/OpenAI response object.
+      2. ``result["usage"]``  — the same, already dict-ified.
+      3. ``last_prompt_tokens`` / ``last_completion_tokens`` on the bound instance
+         (``args[0]``) — THE REAL PATH.
+
+    Why (3) exists: this decorator is applied to ``PromptChain.run_model_async``,
+    whose own docstring states it returns "the message dictionary
+    (response['choices'][0]['message'])". ``usage`` lives on the RESPONSE, one level
+    above the message — so ``hasattr(result, "usage")`` was ALWAYS False and token
+    metrics were never recorded for ANY consumer. Measured before this fix: 3,163
+    MLflow runs logged, zero token metrics. It failed silently — ``init_mlflow()``
+    reports success and runs appear in the UI; only the numbers are absent.
+
+    ``run_model_async`` already computes usage and stores it on the instance, so (3)
+    just reads what is there. Deliberately NOT fixed by attaching ``usage`` to the
+    returned message: that dict is appended to conversation history and sent back to
+    the provider, so an extra key risks breaking strict APIs. The message contract
+    stays untouched.
+    """
+    def _num(v):
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return None
+
+    usage = getattr(result, "usage", None)
+    if usage is None and isinstance(result, Mapping):
+        usage = result.get("usage")
+
+    prompt = completion = total = None
+    if usage is not None:
+        if isinstance(usage, Mapping):
+            prompt = _num(usage.get("prompt_tokens"))
+            completion = _num(usage.get("completion_tokens"))
+            total = _num(usage.get("total_tokens"))
+        else:
+            prompt = _num(getattr(usage, "prompt_tokens", None))
+            completion = _num(getattr(usage, "completion_tokens", None))
+            total = _num(getattr(usage, "total_tokens", None))
+
+    if prompt is None and completion is None and args:
+        inst = args[0]
+        prompt = _num(getattr(inst, "last_prompt_tokens", None))
+        completion = _num(getattr(inst, "last_completion_tokens", None))
+
+    if total is None and (prompt is not None or completion is not None):
+        total = (prompt or 0.0) + (completion or 0.0)
+
+    logged = False
+    for key, val in (("prompt_tokens", prompt),
+                     ("completion_tokens", completion),
+                     ("total_tokens", total)):
+        if val is not None:
+            queue_log_metric(key, val)
+            logged = True
+    return logged
 
 
 def track_llm_call(
@@ -147,14 +212,8 @@ def track_llm_call(
                     queue_log_metric("execution_time_seconds", execution_time)
                     queue_set_tag("status", "success")
 
-                    # Extract token counts from result if available
-                    if hasattr(result, 'usage'):
-                        if hasattr(result.usage, 'prompt_tokens'):
-                            queue_log_metric("prompt_tokens", float(result.usage.prompt_tokens))
-                        if hasattr(result.usage, 'completion_tokens'):
-                            queue_log_metric("completion_tokens", float(result.usage.completion_tokens))
-                        if hasattr(result.usage, 'total_tokens'):
-                            queue_log_metric("total_tokens", float(result.usage.total_tokens))
+                    # Extract token counts (response obj / mapping / instance fallback)
+                    _log_token_usage(result, args)
 
                     return result
 
@@ -198,13 +257,8 @@ def track_llm_call(
                     queue_log_metric("execution_time_seconds", execution_time)
                     queue_set_tag("status", "success")
 
-                    if hasattr(result, 'usage'):
-                        if hasattr(result.usage, 'prompt_tokens'):
-                            queue_log_metric("prompt_tokens", float(result.usage.prompt_tokens))
-                        if hasattr(result.usage, 'completion_tokens'):
-                            queue_log_metric("completion_tokens", float(result.usage.completion_tokens))
-                        if hasattr(result.usage, 'total_tokens'):
-                            queue_log_metric("total_tokens", float(result.usage.total_tokens))
+                    # Extract token counts (response obj / mapping / instance fallback)
+                    _log_token_usage(result, args)
 
                     return result
 

--- a/tests/test_observability_token_usage.py
+++ b/tests/test_observability_token_usage.py
@@ -1,0 +1,98 @@
+"""Token usage must be recorded for the shape PromptChain actually returns.
+
+Regression: `track_llm_call` extracted usage via `hasattr(result, "usage")`, but it
+decorates `PromptChain.run_model_async`, which returns the MESSAGE dict
+(`response["choices"][0]["message"]`). `usage` lives on the RESPONSE, one level up,
+so the check was ALWAYS False and no consumer ever got token metrics — measured:
+3,163 MLflow runs logged, zero token metrics. It failed silently: init_mlflow()
+reports success and runs appear in the UI, only the numbers are missing.
+"""
+
+import pytest
+
+from promptchain.observability.decorators import _log_token_usage
+
+
+class _Usage:
+    def __init__(self, p, c, t=None):
+        self.prompt_tokens = p
+        self.completion_tokens = c
+        if t is not None:
+            self.total_tokens = t
+
+
+class _Response:
+    """What a raw LiteLLM/OpenAI response looks like."""
+    def __init__(self, p, c, t=None):
+        self.usage = _Usage(p, c, t)
+
+
+class _Chain:
+    """What run_model_async's bound instance carries after a call."""
+    def __init__(self, p, c):
+        self.last_prompt_tokens = p
+        self.last_completion_tokens = c
+
+
+@pytest.fixture
+def logged(monkeypatch):
+    """Capture queued metrics instead of shipping them to MLflow."""
+    out = {}
+    monkeypatch.setattr(
+        "promptchain.observability.decorators.queue_log_metric",
+        lambda k, v, step=None: out.__setitem__(k, v),
+    )
+    return out
+
+
+def test_response_object_with_usage(logged):
+    assert _log_token_usage(_Response(11, 22, 33), ()) is True
+    assert logged == {"prompt_tokens": 11.0, "completion_tokens": 22.0, "total_tokens": 33.0}
+
+
+def test_mapping_with_usage_key(logged):
+    payload = {"usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12}}
+    assert _log_token_usage(payload, ()) is True
+    assert logged == {"prompt_tokens": 5.0, "completion_tokens": 7.0, "total_tokens": 12.0}
+
+
+def test_message_dict_falls_back_to_instance(logged):
+    """THE REAL PATH: run_model_async returns a message dict with no usage anywhere."""
+    message = {"role": "assistant", "content": "hi"}
+    chain = _Chain(101, 202)
+    assert _log_token_usage(message, (chain,)) is True
+    assert logged["prompt_tokens"] == 101.0
+    assert logged["completion_tokens"] == 202.0
+    assert logged["total_tokens"] == 303.0        # derived when absent
+
+
+def test_total_is_derived_when_missing(logged):
+    assert _log_token_usage(_Response(3, 4), ()) is True   # no total_tokens on usage
+    assert logged["total_tokens"] == 7.0
+
+
+def test_no_usage_anywhere_is_silent_not_fatal(logged):
+    assert _log_token_usage({"role": "assistant", "content": "x"}, (object(),)) is False
+    assert logged == {}
+
+
+def test_none_result_does_not_raise(logged):
+    assert _log_token_usage(None, ()) is False
+    assert logged == {}
+
+
+def test_non_numeric_usage_is_ignored(logged):
+    payload = {"usage": {"prompt_tokens": "n/a", "completion_tokens": None}}
+    assert _log_token_usage(payload, ()) is False
+    assert logged == {}
+
+
+def test_explicit_usage_wins_over_instance(logged):
+    """A real response's own numbers must not be shadowed by stale instance state."""
+    chain = _Chain(999, 999)
+    assert _log_token_usage(_Response(1, 2, 3), (chain,)) is True
+    assert logged == {"prompt_tokens": 1.0, "completion_tokens": 2.0, "total_tokens": 3.0}
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
Closes #68.

`track_llm_call` extracted usage with `hasattr(result, "usage")` — but it decorates `PromptChain.run_model_async`, whose own docstring states it returns *"the **message** dictionary (`response['choices'][0]['message']`)"*. `usage` lives on the **response**, one level above the message. The check was **always False**, so token metrics were never recorded for any consumer.

**Measured before the fix: 3,163 MLflow runs logged, ZERO token metrics.**

It failed *silently* — `init_mlflow()` logs "MLflow tracking initialized", the experiment and runs appear in the UI, only the numbers are absent. It reads as configured and working, which is why it survived this long.

Doubly blocked: even had usage been in that dict, `hasattr` tests an attribute, not a key.

## Fix

`_log_token_usage()` tries three shapes in order:

| # | shape | when |
|---|---|---|
| 1 | `result.usage` | raw LiteLLM/OpenAI response object (previous behavior, preserved) |
| 2 | `result["usage"]` | the same, already dict-ified |
| 3 | `last_prompt_tokens` / `last_completion_tokens` on the bound instance | **the real path** |

(3) works because `run_model_async` **already computes and stores** these — it simply never put them anywhere the decorator could see. `total` is derived when absent.

**Deliberately NOT fixed by attaching `usage` to the returned message.** That dict is appended to conversation history and sent back to the provider, so an extra key risks breaking strict APIs. The message contract stays untouched.

Explicit usage on the result takes precedence over the instance fields, so stale instance state can never shadow a real response's own numbers.

## Verified live

Against a running MLflow server, the message-dict path that previously logged nothing:

```
metrics.prompt_tokens:     [101.0]
metrics.completion_tokens: [202.0]
metrics.total_tokens:      [303.0]   <- derived
```

## Tests

8 new in `tests/test_observability_token_usage.py`: response object · mapping with `usage` key · **message dict + instance fallback** · derived total · no-usage-anywhere is silent not fatal · `None` result · non-numeric ignored · explicit usage beats instance state.

Pre-existing unrelated failures in `test_observability_unit.py` (3× missing `pytest-asyncio`, 1× a config-default assertion) are unchanged — 4 failed / 22 passed, same as before.

## One honest loose end

#68 also reported `execution_time_seconds` missing on that path. **That did not reproduce** after this change, and nothing here touches that code. Leaving it observed-but-unexplained rather than claiming a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)